### PR TITLE
Feature/berte 532

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [3.4.1] - 2020-09-14
+## [3.4.1] - 2020-10-08
 # Fixed
 - success message did not display hotfix target branch
 - incorrect fix version message for hotfix PR
 - queue UI display order
+- removed password basic auth for github
 
 ## [3.4.0] - 2020-07-24
 # Added

--- a/bert_e/git_host/github/__init__.py
+++ b/bert_e/git_host/github/__init__.py
@@ -16,7 +16,6 @@ import logging
 from collections import defaultdict, namedtuple
 
 from requests import HTTPError
-from requests.auth import HTTPBasicAuth
 from urllib.parse import quote_plus as quote
 
 from bert_e.exceptions import TaskAPIError
@@ -43,14 +42,14 @@ class Client(base.AbstractClient):
             'Accept': 'application/vnd.github.v3+json',
             'User-Agent': 'Bert-E',
             'Content-Type': 'application/json',
-            'From': email
+            'From': email,
+            'Authorization': 'token ' + password
         }
 
         rlog = logging.getLogger('requests.packages.urllib3.connectionpool')
         rlog.setLevel(logging.CRITICAL)
         self.session = base.BertESession()
         self.session.headers.update(headers)
-        self.session.auth = HTTPBasicAuth(login, password)
 
         self.login = login
         self.password = password


### PR DESCRIPTION
Please note: pipeline-deploy will feed a personnal access token as the password for github repos.

However, I did not rename password vars everywhere in order to avoid silently breaking things.

For the github API calls, I changed the basic auth into an authorization header with a personal access token.

For the rest, will use the personal access token passed as a password and it will continue to work after the password basic auth is removed.

For more info, see:

https://developer.github.com/changes/2020-02-14-deprecating-password-auth/

https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token