### PR TITLE
RELENG-6332 configure middleware through env

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,41 @@
+---
+name: build
+
+on:
+  push:
+    branches:
+      - 'user/**'
+      - 'feature/**'
+      - 'improvement/**'
+      - 'bugfix/**'
+      - 'dependabot/**'
+      - 'w/**'
+      - 'q/**'
+
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildk
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.scality.com
+          username: ${{ secrets.REGISTRY_LOGIN }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: "registry.scality.com/bert-e-dev/bert-e:${{ github.sha }}"
+          cache-from: type=gha,scope=bert-e
+          cache-to: type=gha,mode=max,scope=bert-e

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [3.6.21] - 2022-08-05
+# Added
+- Making reverse proxy configuration through env.
+# Fixed
+- Wsgi config for http scheme had a typo.
+
 ## [3.6.19] - 2022-06-30
 # Fixed
 - Ensure check suites build status are stored on webhook event.

--- a/bert_e/server/__init__.py
+++ b/bert_e/server/__init__.py
@@ -70,6 +70,9 @@ def setup_server(bert_e):
     """Create and configure Flask server app."""
     app = Flask(__name__)
 
+    app_prefix = os.getenv('APP_PREFIX', '/')
+    app_scheme = os.getenv('APP_SCHEME', None)
+    app_server = os.getenv('APP_SERVER', None)
     app.config.update({
         'WEBHOOK_LOGIN': os.environ['WEBHOOK_LOGIN'],
         'WEBHOOK_PWD': os.environ['WEBHOOK_LOGIN'],
@@ -77,8 +80,12 @@ def setup_server(bert_e):
         'CLIENT_SECRET': os.environ['BERT_E_CLIENT_SECRET'],
         'WTF_CSRF_SECRET_KEY': secrets.token_hex(24),
     })
-
-    app.wsgi_app = ReverseProxied(app.wsgi_app)
+    app.wsgi_app = ReverseProxied(
+        app.wsgi_app,
+        app_prefix,
+        app_scheme,
+        app_server
+    )
 
     app.bert_e = bert_e
 

--- a/bert_e/server/reverse_proxy.py
+++ b/bert_e/server/reverse_proxy.py
@@ -23,11 +23,14 @@ class ReverseProxied(object):
         - app: the WSGI application
 
     """
-    def __init__(self, app):
+    def __init__(self, app, prefix=None, scheme=None, server=None):
         self.app = app
+        self.prefix = prefix
+        self.scheme = scheme
+        self.server = server
 
     def __call__(self, environ, start_response):
-        script_name = environ.get('HTTP_X_SCRIPT_NAME', None)
+        script_name = self.prefix
         if script_name is not None:
             environ['SCRIPT_NAME'] = script_name
             path_info = environ['PATH_INFO']
@@ -35,11 +38,11 @@ class ReverseProxied(object):
                 path_info = path_info[len(script_name):]
                 environ['PATH_INFO'] = path_info
 
-        scheme = environ.get('HTTP_X_SCHEME', None)
+        scheme = self.scheme
         if scheme is not None:
-            environ['wsgi_url_scheme'] = scheme
+            environ['wsgi.url_scheme'] = scheme
 
-        server = environ.get('HTTP_X_FORWARDED_SERVER', None)
+        server = self.server
         if server:
             environ['HTTP_HOST'] = server
 


### PR DESCRIPTION
UI was throwing invalid input when behind a nginx ingress

Hard to get a picture of how the ingress behave, making
reverse proxy config manageable through env vars.

It was spotted that there was a typo in the config
for the http scheme, which was decisive in finding
the root cause of the issue
