### PR TITLE
PTFE-583 Option to create integration branches when requested

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [3.8.0] - 2023-06-13
+# Added
+- Introducing new option `create_integration_branches`
+  to allow the creation of integration branches on demand.
+
 ## [3.7.0] - 2022-08-08
 # Added
 - Support config settings through environment.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ tox -e run
 A series of test scenario will be executed locally using mocks.
 
 ```shell
-$ tox -e tests
+$ tox run -e tests
 ```
 
 ### Run tests against githost

--- a/bert_e/docs/USER_DOC.md
+++ b/bert_e/docs/USER_DOC.md
@@ -119,6 +119,7 @@ __Bert-E__.
 | bypass_peer_approval      | Bypass the pull request peer's approval | yes | no
 | bypass_leader_approval    | Bypass the pull request leader's approval | yes | no
 | create_pull_requests      | Let __Bert-E__ create pull requests corresponding to integration branches | no | no
+| create_integration_branches | Request __Bert-E__ to create integration branches and move forward with the gitwaterflow | no | no
 | no_octopus                | Prevent Wall-E from doing any octopus merge and use multiple consecutive merge instead | yes | no
 | unanimity                 | Change review acceptance criteria from `one reviewer at least` to `all reviewers` (**this feature is not supported on GitHub**) | no | no
 | wait                      | Instruct __Bert-E__ not to run until further notice | no | no
@@ -169,6 +170,20 @@ The latest code from the pull request is merged with the latest code from the
 target development branch. This code is then tested in the build pipeline,
 before any merge can happen. There are as many integration branches as there
 are target branches.
+
+The integration branches are mandatory in the GitWaterFlow process,
+and by default they are automatically created when a pull request is
+opened.
+This behaviour can be changed with the `always_create_integration_branches`
+parameter in the bot settings:
+
+* *true* (default): integration branches are created automatically when a
+  pull request is opened.
+* *false*: users will be required to explicitly request the creation
+  of integration branches by adding a `/create_integration_branches`
+  comment in their pull request.
+  The above allow to temporize the creation of those branches as
+  in the review process requested changes as expected.
 
 On the Git project, the name of the integration branches follow the format:
 

--- a/bert_e/exceptions.py
+++ b/bert_e/exceptions.py
@@ -229,6 +229,11 @@ class NotAuthor(TemplateException):
     template = "not_author.md"
 
 
+class RequestIntegrationBranches(TemplateException):
+    code = 135
+    template = "request_integration_branches.md"
+
+
 # internal exceptions
 class UnableToSendEmail(InternalException):
     code = 201

--- a/bert_e/settings.py
+++ b/bert_e/settings.py
@@ -125,6 +125,8 @@ class SettingsSchema(Schema):
     # Settings defined in config files
     always_create_integration_pull_requests = fields.Bool(
         required=False, load_default=True)
+    always_create_integration_branches = fields.Bool(
+        required=False, load_default=True)
 
     frontend_url = fields.Str(required=False, load_default='')
 

--- a/bert_e/templates/request_integration_branches.md
+++ b/bert_e/templates/request_integration_branches.md
@@ -1,0 +1,15 @@
+{% extends "message.md" %}
+
+{% block title -%}
+Request integration branches
+{% endblock %}
+
+{% block message %}
+Waiting for integration branch creation to be requested by the user.
+
+To request integration branches, please comment on this pull request with the following command:
+
+```
+/create_integration_branches
+```
+{% endblock %}

--- a/bert_e/workflow/gitwaterflow/__init__.py
+++ b/bert_e/workflow/gitwaterflow/__init__.py
@@ -34,7 +34,8 @@ from .utils import (
     bypass_author_approval, bypass_leader_approval, bypass_build_status
 )
 from .commands import setup  # noqa
-from .integration import (create_integration_branches,
+from .integration import (check_integration_branches,
+                          create_integration_branches,
                           create_integration_pull_requests,
                           merge_integration_branches,
                           notify_integration_data,
@@ -158,6 +159,7 @@ def _handle_pull_request(job: PullRequestJob):
     check_branch_compatibility(job)
     jira_checks(job)
 
+    check_integration_branches(job)
     wbranches = list(create_integration_branches(job))
     use_queue = job.settings.use_queue
     if use_queue and queueing.already_in_queue(job, wbranches):

--- a/bert_e/workflow/gitwaterflow/commands.py
+++ b/bert_e/workflow/gitwaterflow/commands.py
@@ -210,6 +210,11 @@ def setup(defaults={}):
         privileged=False,
         default=defaults.get("create_pull_requests", False))
     Reactor.add_option(
+        "create_integration_branches",
+        "Allow the creation of integration branches.",
+        privileged=False,
+        default=defaults.get("create_integration_branches", False))
+    Reactor.add_option(
         "no_octopus",
         "Prevent Wall-E from doing any octopus merge and use multiple "
         "consecutive merge instead",

--- a/bert_e/workflow/gitwaterflow/integration.py
+++ b/bert_e/workflow/gitwaterflow/integration.py
@@ -136,6 +136,16 @@ def update_integration_branches(job, wbranches):
         prev = branch
 
 
+def check_integration_branches(job):
+    """Check if the integration branches can be created."""
+
+    if (job.settings.always_create_integration_branches is False and
+            job.settings.create_integration_branches is False):
+        raise exceptions.RequestIntegrationBranches(
+            active_options=job.active_options,
+        )
+
+
 def check_conflict(job, dst: git.Branch, src: git.Branch):
     """Check conflict between the source and destination branches of a PR."""
     # Create a temporary branch starting off from the destination branch, only

--- a/charts/bert-e/templates/settings.yaml
+++ b/charts/bert-e/templates/settings.yaml
@@ -21,6 +21,7 @@ stringData:
     robot_email: {{ .Values.bertE.robot.email | quote }}
     organization: {{ .Values.bertE.oauth.organization }}
     always_create_integration_pull_requests: {{ .Values.bertE.gating.alwaysCreateIntegrationPullRequests }}
+    always_create_integration_branches: {{ .Values.bertE.gating.alwaysCreateIntegrationBranches }}
     {{- if eq .Values.bertE.repository.gitHost "bitbucket" }}
     pull_request_base_url: https://bitbucket.org/{{ .Values.bertE.repository.owner }}/{{ .Values.bertE.repository.slug }}/pull-requests/{pr_id}
     commit_base_url: https://bitbucket.org/{{ .Values.bertE.repository.owner }}/{{ .Values.bertE.repository.slug }}/commits/{commit_id}

--- a/charts/bert-e/values.yaml
+++ b/charts/bert-e/values.yaml
@@ -130,6 +130,21 @@ bertE:
     ##
     alwaysCreateIntegrationPullRequests: true
 
+    ## always_create_integration_branches decides whether integration
+    ## branches are created in automatically when a pull request is opened.
+    ##
+    ## Bert-e will by default automatically create them.
+    ##
+    ##   Set this setting to false to require users to explicitly request the creation
+    ##   of integration branches by adding a `/create_integration_branches`
+    ##   comment in their pull request.
+    ##
+    ##   The above allow to temporize the creation of those branches as
+    ##   in the review process requested changes as expected.
+    ##
+    ##   default value: true
+    ##
+    alwaysCreateIntegrationBranches: true
     ## buildKey is the label of the key to look for in commit statuses.
     ##
     ##   default value: pre-merge


### PR DESCRIPTION
This PR add the possibility to create integration branches when requested. It does not remove the integration branches as they are essential to the gitwaterflow.

PR currently in draft mode as we're studying adding this feature, initially requested as a work estimation. But estimating would have took the same time as writing the code so there it is.

The code is functional and a testcase was added.
Further testing and review will be made if we move the topic forward.