### PR TITLE
PTFE-2192 add more information to build failed status

### DIFF
--- a/bert_e/git_host/github/__init__.py
+++ b/bert_e/git_host/github/__init__.py
@@ -593,7 +593,8 @@ class AggregatedWorkflowRuns(base.AbstractGitHostObject):
     def url(self):
         if len(self._workflow_runs) == 0:
             return None
-        return f"https://github.com/{self.full_repo}/commit/{self.commit}"
+
+        return f"https://github.com/{self.full_repo}/actions?query=branch%3A{self.branch}" # noqa
 
     @property
     def commit(self) -> str | None:

--- a/bert_e/templates/build_failed.md
+++ b/bert_e/templates/build_failed.md
@@ -5,5 +5,10 @@ Build failed
 {% endblock %}
 
 {% block message %}
-The {% if build_url %}[build]({{ build_url }}){% else %}build{% endif %}{% if commit_url %} for [commit]({{ commit_url }}){% endif %} did not succeed in branch {{ branch }}.
+The {% if build_url -%}[build]({{ build_url }}) {% else -%}build {% endif -%}
+{% if commit_url -%}for [commit]({{ commit_url }}) {% endif %}did not succeed in branch
+{%- if githost == 'bitbucket' %} [{{ branch.name }}](https://bitbucket.org/{{ owner }}/{{ slug }}/branch/{{ branch.name }}?dest={{ branch.dst_branch }})
+{%- elif githost == 'github' %} [{{ branch.name }}](https://github.com/{{ owner }}/{{ slug }}/compare/{{ branch.dst_branch }}...{{ branch.name }})
+{%- else %} `{{ branch.name }}`
+{%- endif -%}
 {% endblock %}

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -822,16 +822,30 @@ class BuildFailedTest(unittest.TestCase):
     def test_build_fail_with_build_url(self):
         build_url = 'http://host/path/to/the?build=url'
         commit_url = 'http://host/path/to/the?commit=url'
-        build_fail = exns.BuildFailed(branch='spam', build_url=build_url,
-                                      commit_url=commit_url,
-                                      active_options=None)
+        branch = gwfb.IntegrationBranch(FakeGitRepo(), 'w/5.0/feature/TEST-01')
+
+        build_fail = exns.BuildFailed(
+            branch=branch,
+            build_url=build_url,
+            commit_url=commit_url,
+            githost="github",
+            active_options=None,
+            owner="owner",
+            slug="slug",
+        )
         self.assertIn('The [build]({}) for [commit]({})'
                       ' did not succeed'.format(build_url, commit_url),
                       build_fail.msg)
 
     def test_build_fail_with_url_to_none(self):
-        build_fail = exns.BuildFailed(branch='spam', build_url=None,
-                                      commit_url=None, active_options=None)
+        branch = gwfb.IntegrationBranch(FakeGitRepo(), 'w/5.0/feature/TEST-01')
+        build_fail = exns.BuildFailed(
+            branch=branch,
+            build_url=None,
+            githost="mock",
+            commit_url=None,
+            active_options=None
+        )
         self.assertIn('The build did not succeed', build_fail.msg)
 
 
@@ -3000,7 +3014,7 @@ pr_author_options:
                         backtrace=True)
         except exns.BuildFailed as excp:
             self.assertIn(
-                "did not succeed in branch w/10/bugfix/TEST-00081",
+                "did not succeed in branch `w/10/bugfix/TEST-00081`",
                 excp.msg,
             )
         else:
@@ -3420,7 +3434,7 @@ pr_author_options:
                         backtrace=True)
         except exns.BuildFailed as excp:
             self.assertIn(
-                "did not succeed in branch w/10/bugfix/TEST-00081",
+                "did not succeed in branch `w/10/bugfix/TEST-00081`",
                 excp.msg,
             )
         else:

--- a/bert_e/tests/unit/test_github_build_status.py
+++ b/bert_e/tests/unit/test_github_build_status.py
@@ -98,8 +98,8 @@ def test_aggregated_workflow_run(client, workflow_run_json):
     owner = \
         workflow_run_json['workflow_runs'][0]['repository']['owner']['login']
     repo = workflow_run_json['workflow_runs'][0]['repository']['name']
-    url = f"https://github.com/{full_name}/commit/{head_sha}"
     branch = workflow_run_json['workflow_runs'][0]['head_branch']
+    url = f"https://github.com/{full_name}/actions?query=branch%3A{branch}"
     assert url == workflow_runs.url
     assert head_sha == workflow_runs.commit
     assert owner == workflow_runs.owner

--- a/bert_e/workflow/gitwaterflow/__init__.py
+++ b/bert_e/workflow/gitwaterflow/__init__.py
@@ -653,12 +653,14 @@ def check_build_status(job, wbranches):
     if worst_status in ('FAILED', 'STOPPED'):
         raise messages.BuildFailed(
             active_options=job.active_options,
-            branch=worst.name,
+            branch=worst,
             build_url=job.project_repo.get_build_url(
-                worst.get_latest_commit,
-                key),
+                worst.get_latest_commit(), key),
             commit_url=job.project_repo.get_commit_url(
                 worst.get_latest_commit()),
+            githost=job.settings.repository_host,
+            owner=job.settings.repository_owner,
+            slug=job.settings.repository_slug,
         )
     elif worst_status == 'NOTSTARTED':
         raise messages.BuildNotStarted()


### PR DESCRIPTION
An attempt into adding a bit more information into the BuildFailed status sent by bert-e.

Was hoping we could add a more precise url since the API allows the filter by sha1 but can only filter by branch instead, which is not ideal as IMHO the commit view give a better information into which builds needs to be rebuilt.