### PR TITLE
(PTFE-2504) develop branch with three digits

### DIFF
--- a/bert_e/exceptions.py
+++ b/bert_e/exceptions.py
@@ -290,6 +290,17 @@ class BranchNameInvalid(InternalException):
         super(BranchNameInvalid, self).__init__(msg)
 
 
+class ReleaseAlreadyExists(InternalException):
+    code = 204
+
+    def __init__(self, branch, tag):
+        msg = 'Branch %r must be deleted as %r has been created, ' \
+              'you must use a hotfix branch if you really intend ' \
+              'to target this version.' \
+              % (branch, tag)
+        super(ReleaseAlreadyExists, self).__init__(msg)
+
+
 class UnrecognizedBranchPattern(InternalException):
     code = 207
 
@@ -435,10 +446,21 @@ class MasterQueueMissing(QueueValidationError):
     code = 'Q001'
     auto_recovery = False
 
+    @staticmethod
+    def _format_version(version):
+        if not version:
+            return '[]'
+        if len(version) == 1 or (len(version) > 1 and version[1] is None):
+            return f"{version[0]}"
+        if len(version) == 2 or (len(version) > 2 and version[2] is None):
+            return f"{version[0]}.{version[1]}"
+        return f"{version[0]}.{version[1]}.{version[2]}"
+
     def __init__(self, version):
-        msg = 'there are integration queues on this version ' \
-              'but q/%s.%s is missing' % version
-        super(MasterQueueMissing, self).__init__(msg)
+        version_str = self._format_version(version)
+        msg = "there are integration queues on " \
+            f"this version but q/{version_str} is missing"
+        super().__init__(msg)
 
 
 class MasterQueueLateVsDev(QueueValidationError):

--- a/bert_e/tests/unit/test_exceptions_master_queue_missing.py
+++ b/bert_e/tests/unit/test_exceptions_master_queue_missing.py
@@ -1,0 +1,31 @@
+from bert_e.exceptions import MasterQueueMissing
+
+
+def test_master_queue_missing_major_only():
+    # Covers version with length 1
+    exc = MasterQueueMissing((10,))
+    assert 'q/10 is missing' in str(exc)
+
+
+def test_master_queue_missing_major_minor():
+    # Covers version with length 2
+    exc = MasterQueueMissing((10, 0))
+    assert 'q/10.0 is missing' in str(exc)
+
+
+def test_master_queue_missing_major_minor_none_micro():
+    # Covers version with length >=3 and micro is None
+    exc = MasterQueueMissing((10, 0, None))
+    assert 'q/10.0 is missing' in str(exc)
+
+
+def test_master_queue_missing_major_minor_micro():
+    # Covers version with length >=3 and micro is not None
+    exc = MasterQueueMissing((10, 0, 5))
+    assert 'q/10.0.5 is missing' in str(exc)
+
+
+def test_master_queue_missing_fallback():
+    # Covers fallback case
+    exc = MasterQueueMissing([])
+    assert 'q/[] is missing' in str(exc)

--- a/bert_e/tests/unit/test_sorted.py
+++ b/bert_e/tests/unit/test_sorted.py
@@ -51,3 +51,33 @@ def test_sorted_versions():
     sorted_versions = sorted(versions, key=version_key, reverse=True)
 
     assert sorted_versions == expected
+
+
+def test_compare_branches_major_minor_vs_major_only():
+    branch1 = ((4, 3),)
+    branch2 = ((4, None),)
+    assert compare_branches(branch1, branch2) == -1
+
+
+def test_compare_branches_major_only_vs_major_only_returns_0():
+    branch1 = ((4, None),)  # major-only
+    branch2 = ((4, None),)     # major.only
+    assert compare_branches(branch1, branch2) == 0
+
+
+def test_compare_branches_major_only_vs_major_minor():
+    branch1 = ((4, None),)
+    branch2 = ((4, 3),)
+    assert compare_branches(branch1, branch2) == 1
+
+
+def test_compare_branches_major_minor_micro_vs_major_minor():
+    branch1 = ((4, 3, 2),)
+    branch2 = ((4, 3),)
+    assert compare_branches(branch1, branch2) == -2
+
+
+def test_compare_branches_major_minor_vs_major_minor_micro():
+    branch1 = ((4, 3),)
+    branch2 = ((4, 3, 2),)
+    assert compare_branches(branch1, branch2) == 2


### PR DESCRIPTION
# PR: Support for development/x.y.z Branches (Three-Digit Development Branches)

## Summary
This pull request introduces full support for three-digit development branches (e.g., `development/x.y.z`) in the GitWaterFlow cascade logic. The changes ensure that the system correctly handles, sorts, and calculates next versions for both two-digit (`development/x.y`) and three-digit (`development/x.y.z`) development branches.

## Key Changes
- **Cascade Logic:**
  - The cascade now properly includes and orders three-digit development branches alongside their two-digit parents.
  - When the destination is a three-digit branch, its parent two-digit branch is always included in the cascade, and the order is: three-digit branch first, then its parent, then the rest.
  - The default sorting ensures that for the same major/minor, the two-digit branch always comes before any three-digit branch.

- **Next Micro Version Calculation:**
  - For two-digit branches, the next micro version is now always the first available micro not already claimed by a three-digit branch, regardless of whether that branch is ignored in the cascade.
  - The logic skips all micro versions for which a `development/x.y.z` branch exists, ensuring no conflicts or duplicate versions.
  - Each target version is only added once to the list, preventing duplicates when both a two-digit and a three-digit branch would propose the same next version.

- **Tests:**
  - The test suite has been updated to cover all edge cases, including mixed two-digit and three-digit development branches, correct cascade ordering, and version calculation.
  - Tests now ensure that the cascade and version logic behave as expected for all combinations of present and ignored branches.

## Impact
- No breaking changes for existing two-digit or major-only development branch workflows.
- Three-digit development branches are now fully supported and integrated into the cascade and versioning logic.
- Improved reliability and predictability for release and merge automation.

---