### PR TITLE
Improvement/pre ga hotfix support

### DIFF
--- a/bert_e/exceptions.py
+++ b/bert_e/exceptions.py
@@ -191,16 +191,19 @@ class Queued(TemplateException):
     template = 'queued.md'
     status = "in_progress"
 
-    def __init__(self, branches, ignored, issue, author, active_options):
+    def __init__(self, branches, ignored, issue, author, active_options,
+                 pending_hotfixes=None):
         """Save args for later use by tests."""
         self.branches = branches
         self.ignored = ignored
         self.issue = issue
         self.author = author
         self.active_options = active_options
+        self.pending_hotfixes = pending_hotfixes or []
         super(Queued, self).__init__(
             branches=branches,
             ignored=ignored,
+            pending_hotfixes=pending_hotfixes or [],
             issue=issue,
             author=author,
             active_options=active_options

--- a/bert_e/exceptions.py
+++ b/bert_e/exceptions.py
@@ -435,6 +435,11 @@ class WrongDestination(TemplateException):
     template = 'incorrect_destination.md'
 
 
+class PendingHotfixVersionReminder(InformationException):
+    code = 223
+    template = 'pending_hotfix_version_reminder.md'
+
+
 class QueueValidationError(Exception):
     """Extend simple string class with an error code and recovery potential."""
     code = 'Q000'

--- a/bert_e/jobs/create_branch.py
+++ b/bert_e/jobs/create_branch.py
@@ -62,7 +62,10 @@ def create_branch(job: CreateBranchJob):
 
     # do not allow recreating a previously existing identical branch
     # (unless archive tag is manually removed)
-    if new_branch.version in repo.cmd('git tag').split('\n')[:-1]:
+    # Hotfix archive tags use format 'X.Y.Z.hfrev.archived_hotfix_branch',
+    # not just 'X.Y.Z.hfrev', so skip this check for hotfix branches.
+    if not isinstance(new_branch, HotfixBranch) and \
+            new_branch.version in repo.cmd('git tag').split('\n')[:-1]:
         raise exceptions.JobFailure('Cannot create branch %r because there is '
                                     'already an archive tag %r in the '
                                     'repository.' %
@@ -81,8 +84,10 @@ def create_branch(job: CreateBranchJob):
     # ...or determine the branching point automatically
     else:
         if isinstance(new_branch, HotfixBranch):
-            # start from tag X.Y.Z.0
-            job.settings.branch_from = new_branch.version + '.0'
+            # start from tag X.Y.Z.0 (use 3-digit base to avoid double .0)
+            base_ver = '%d.%d.%d' % (new_branch.major,
+                                     new_branch.minor, new_branch.micro)
+            job.settings.branch_from = base_ver + '.0'
         else:
             job.settings.branch_from = dev_branches[0]
             for dev_branch in dev_branches:

--- a/bert_e/lib/git.py
+++ b/bert_e/lib/git.py
@@ -16,7 +16,7 @@ import logging
 import os
 import time
 from collections import defaultdict
-from pipes import quote
+from shlex import quote
 from shutil import rmtree
 from tempfile import mkdtemp
 

--- a/bert_e/templates/incorrect_fix_version.md
+++ b/bert_e/templates/incorrect_fix_version.md
@@ -13,8 +13,8 @@ The `Fix Version/s` in issue {{ issue.key }} contains:
 * *None*
 {% endfor %}
 
-{% if expect_versions|length == 1 and expect_versions[0].split('.')|length == 4 %}
-Considering where you are trying to merge, I expected to find at least:
+{% if expect_versions and expect_versions[-1].split('.')|length == 4 %}
+Considering where you are trying to merge, I expected to find at least one of:
 {% else %}
 Considering where you are trying to merge, I ignored possible hotfix versions and I expected to find:
 {% endif %}

--- a/bert_e/templates/incorrect_fix_version.md
+++ b/bert_e/templates/incorrect_fix_version.md
@@ -13,8 +13,8 @@ The `Fix Version/s` in issue {{ issue.key }} contains:
 * *None*
 {% endfor %}
 
-{% if expect_versions and expect_versions[-1].split('.')|length == 4 %}
-Considering where you are trying to merge, I expected to find at least one of:
+{% if expect_versions|length == 1 and expect_versions[0].split('.')|length == 4 %}
+Considering where you are trying to merge, I expected to find at least:
 {% else %}
 Considering where you are trying to merge, I ignored possible hotfix versions and I expected to find:
 {% endif %}

--- a/bert_e/templates/pending_hotfix_version_reminder.md
+++ b/bert_e/templates/pending_hotfix_version_reminder.md
@@ -1,0 +1,19 @@
+{% extends "message.md" %}
+
+{% block title -%}
+Pending hotfix branch
+{% endblock %}
+
+{% block message %}
+:information_source: Issue {{ issue.key }} contains the following
+pre-GA hotfix fix version(s):
+
+{% for version in hotfix_versions %}
+* `{{ version }}`
+{% endfor %}
+
+This means the change is expected to land on the corresponding hotfix
+branch as well. Please make sure to open a separate cherry-pick pull
+request targeting that hotfix branch so that the fix is applied
+everywhere it needs to be.
+{% endblock %}

--- a/bert_e/templates/queued.md
+++ b/bert_e/templates/queued.md
@@ -23,6 +23,15 @@ The following branches will **NOT** be impacted:
 {% endfor %}
 {% endif %}
 
+{% if pending_hotfixes %}
+:warning: This pull request does **not** target the following hotfix
+branch(es). Please open a separate cherry-pick pull request to each:
+
+{% for branch in pending_hotfixes -%}
+* `{{ branch.name }}`
+{% endfor %}
+{% endif %}
+
 There is no action required on your side. You will be notified here once
 the changeset has been merged. In the unlikely event that the changeset
 fails permanently on the queue, a member of the admin team will

--- a/bert_e/templates/successful_merge.md
+++ b/bert_e/templates/successful_merge.md
@@ -16,6 +16,15 @@ The following branches have **NOT** changed:
 {% endfor %}
 {% endif %}
 
+{% if pending_hotfixes %}
+:warning: This pull request did **not** target the following hotfix
+branch(es). Please open a separate cherry-pick pull request to each:
+
+{% for branch in pending_hotfixes -%}
+* `{{ branch.name }}`
+{% endfor %}
+{% endif %}
+
 Please check the status of the associated issue {{ issue }}.
 
 Goodbye {{ author }}.

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -6033,6 +6033,42 @@ class TestQueueing(RepositoryTests):
             self.handle(sha1, options=self.bypass_all, backtrace=True)
         self.assertEqual(self.prs_in_queue(), set())
 
+    def test_pr_hotfix_no_requeue_after_ga(self):
+        """PR queued pre-GA must not be re-queued after the GA tag is pushed.
+
+        Without the already_in_queue prefix-scan fix, pushing 10.0.0.0 causes
+        already_in_queue to look for q/w/{id}/10.0.0.1/... (hfrev now 1) which
+        does not exist, so the PR is incorrectly re-queued and a new orphaned
+        q/10.0.0.1 branch is created.
+        """
+        # Step 1 — queue PR before GA tag exists.
+        pr = self.create_pr('bugfix/TEST-00000', 'hotfix/10.0.0')
+        with self.assertRaises(exns.Queued):
+            self.handle(pr.id, options=self.bypass_all, backtrace=True)
+        self.assertEqual(self.prs_in_queue(), {pr.id})
+
+        # Step 2 — push the GA tag, advancing hfrev from 0 to 1.
+        self.gitrepo.cmd('git tag 10.0.0.0')
+        self.gitrepo.cmd('git push --tags')
+
+        # Step 3 — re-handle the PR; must be NothingToDo, not Queued again.
+        with self.assertRaises(exns.NothingToDo):
+            self.handle(pr.id, options=self.bypass_all, backtrace=True)
+
+        # No second q/w branch should have been created (would appear if
+        # the PR was incorrectly re-queued with 10.0.0.1).
+        qbranches = self.get_qint_branches()
+        self.assertFalse(
+            any('10.0.0.1' in b for b in qbranches),
+            'orphaned 10.0.0.1 queue branch found: %s' % qbranches)
+
+        # Step 4 — original pre-GA queue branch still builds and merges fine.
+        sha1 = self.set_build_status_on_branch_tip(
+            'q/w/%d/10.0.0.0/bugfix/TEST-00000' % pr.id, 'SUCCESSFUL')
+        with self.assertRaises(exns.Merged):
+            self.handle(sha1, options=self.bypass_all, backtrace=True)
+        self.assertEqual(self.prs_in_queue(), set())
+
     def test_pr_hotfix_alone(self):
         self.gitrepo.cmd('git tag 10.0.0.0')
         self.gitrepo.cmd('git push --tags')

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -1079,6 +1079,7 @@ class RepositoryTests(unittest.TestCase):
                 raise exns.SuccessMessage(
                     branches=queued_excp.branches,
                     ignored=queued_excp.ignored,
+                    pending_hotfixes=queued_excp.pending_hotfixes,
                     issue=queued_excp.issue,
                     author=queued_excp.author,
                     active_options=queued_excp.active_options)

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -480,6 +480,40 @@ class QuickTest(unittest.TestCase):
         tags = ['9.5.2', '10.0.0.0']
         self.finalize_cascade(branches, tags, destination, fixver)
 
+    def test_branch_cascade_mixed_3digit_and_pre_ga_hotfix(self):
+        """Full mixed cascade: 3-digit dev branches, pre-GA hotfix, 2-digit
+        and 1-digit dev branches all coexist correctly.
+
+        Scenario: dev/9.5.3, hotfix/10.0.0 (pre-GA), dev/10.0.1, dev/10.1,
+        dev/10.  Verifies that:
+        - a PR from dev/9.5.3 cascades through 10.0.1 -> 10.1 -> 10
+        - dev/10.0.1 targets 10.0.2
+        - dev/10.1 targets 10.1.0
+        - dev/10 targets 10.2.0 (latest_minor comes from dev/10.1, not hotfix)
+        - hotfix/10.0.0 does not appear in the cascade destination list
+        """
+        destination = 'development/9.5.3'
+        branches = OrderedDict({
+            1: {'name': 'development/9.5.3', 'ignore': False},
+            2: {'name': 'hotfix/10.0.0', 'ignore': True},
+            3: {'name': 'development/10.0.1', 'ignore': False},
+            4: {'name': 'development/10.1', 'ignore': False},
+            5: {'name': 'development/10', 'ignore': False},
+        })
+        # Pre-GA: hotfix/10.0.0 exists but no 10.0.0.X tag yet.
+        # 3-digit branches (9.5.3, 10.0.1) target their own version because
+        # there are no ancestor 2-digit branches (dev/9.5, dev/10.0) in the
+        # cascade to drive _next_micro.
+        # dev/10.1 → 10.1.0, dev/10 → 10.2.0 (latest_minor=1 from dev/10.1).
+        tags = ['9.5.0', '9.5.1']
+        fixver = ['9.5.3', '10.0.1', '10.1.0', '10.2.0']
+        self.finalize_cascade(branches, tags, destination, fixver)
+
+        # Post-GA: 10.0.0.0 tag is ignored (no dev/10.0 or dev/10.0.0 in
+        # cascade), so targets are unchanged.
+        tags = ['9.5.0', '9.5.1', '10.0.0.0']
+        self.finalize_cascade(branches, tags, destination, fixver)
+
     def test_branch_cascade_target_three_digit_dev(self):
         """Test cascade targeting three-digit development branch"""
         destination = 'development/4.3.17'

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -441,6 +441,10 @@ class QuickTest(unittest.TestCase):
             8: {'name': 'hotfix/10.0.4', 'ignore': True},
             9: {'name': 'development/10.0', 'ignore': True}
         })
+        # Pre-GA: no 6.6.6.X tag yet — target version must be 6.6.6.0
+        tags = ['4.3.16', '4.3.17', '5.1.3', '10.0.3.1']
+        fixver = ['6.6.6.0']
+        self.finalize_cascade(branches, tags, destination, fixver)
         tags = ['4.3.16', '4.3.17', '5.1.3', '6.6.6', '10.0.3.1']
         fixver = ['6.6.6.1']
         self.finalize_cascade(branches, tags, destination, fixver)
@@ -453,6 +457,27 @@ class QuickTest(unittest.TestCase):
         self.finalize_cascade(branches, tags, destination, fixver)
         tags = ['4.3.16', '4.3.17', '5.1.3', '6.6.6.1', '6.6.6.2', '10.0.3.1']
         fixver = ['6.6.6.3']
+        self.finalize_cascade(branches, tags, destination, fixver)
+
+    def test_branch_cascade_dev_with_pre_ga_hotfix(self):
+        """development/<major> must target <major>.<minor+1>.0 once
+        hotfix/<major>.<minor>.0 exists, even without the GA tag."""
+        # Use development/9.5 (2-digit) as source so tags on the 9.5 line
+        # don't conflict with the 3-digit dev branch path.
+        destination = 'development/9.5'
+        branches = OrderedDict({
+            1: {'name': 'development/9.5', 'ignore': False},
+            2: {'name': 'hotfix/10.0.0', 'ignore': True},
+            3: {'name': 'development/10', 'ignore': False},
+        })
+        # Pre-GA: hotfix/10.0.0 exists but no 10.0.0.X tag yet.
+        # development/10 must target 10.1.0, NOT 10.0.0.
+        tags = ['9.5.2']
+        fixver = ['9.5.3', '10.1.0']
+        self.finalize_cascade(branches, tags, destination, fixver)
+
+        # Post-GA: 10.0.0.0 tag present — development/10 still targets 10.1.0
+        tags = ['9.5.2', '10.0.0.0']
         self.finalize_cascade(branches, tags, destination, fixver)
 
     def test_branch_cascade_target_three_digit_dev(self):
@@ -5895,6 +5920,28 @@ class TestQueueing(RepositoryTests):
         sha1 = self.set_build_status_on_branch_tip(
             'q/w/%d/10.0.0.1/bugfix/TEST-00002' % pr2.id, 'SUCCESSFUL')
 
+        with self.assertRaises(exns.Merged):
+            self.handle(sha1, options=self.bypass_all, backtrace=True)
+        self.assertEqual(self.prs_in_queue(), set())
+
+    def test_pr_hotfix_pre_ga(self):
+        """PR targeting a hotfix branch before GA (no 10.0.0.X tag yet) must
+        use version 10.0.0.0 for the queue branch and Jira fix version."""
+        # No tag for 10.0.0 at all — pre-GA state
+        pr = self.create_pr('bugfix/TEST-00000', 'hotfix/10.0.0')
+        with self.assertRaises(exns.Queued):
+            self.handle(pr.id, options=self.bypass_all, backtrace=True)
+        self.assertEqual(self.prs_in_queue(), {pr.id})
+
+        # Queue branch must use 10.0.0.0 (not 10.0.0.1 or 10.0.0.-1)
+        sha1 = self.set_build_status_on_branch_tip(
+            'q/w/%d/10.0.0.0/bugfix/TEST-00000' % pr.id, 'FAILED')
+        with self.assertRaises(exns.QueueBuildFailed):
+            self.handle(sha1, options=self.bypass_all, backtrace=True)
+        self.assertEqual(self.prs_in_queue(), {pr.id})
+
+        sha1 = self.set_build_status_on_branch_tip(
+            'q/w/%d/10.0.0.0/bugfix/TEST-00000' % pr.id, 'SUCCESSFUL')
         with self.assertRaises(exns.Merged):
             self.handle(sha1, options=self.bypass_all, backtrace=True)
         self.assertEqual(self.prs_in_queue(), set())

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -6033,6 +6033,18 @@ class TestQueueing(RepositoryTests):
             self.handle(sha1, options=self.bypass_all, backtrace=True)
         self.assertEqual(self.prs_in_queue(), set())
 
+    def test_dev_pr_reminder_about_pre_ga_hotfix(self):
+        """A PR to development/10 must mention hotfix/10.0.0 in the Queued
+        message (pending_hotfixes reminder) when hotfix/10.0.0 is pre-GA."""
+        # No GA tag — hotfix/10.0.0 is a phantom for the dev/10 cascade.
+        pr = self.create_pr('bugfix/TEST-00001', 'development/10')
+        try:
+            self.handle(pr.id, options=self.bypass_all, backtrace=True)
+            self.fail('Expected Queued or SuccessMessage exception')
+        except (exns.Queued, exns.SuccessMessage) as e:
+            self.assertIn('hotfix/10.0.0', e.msg,
+                          'Reminder about hotfix/10.0.0 missing from message')
+
     def test_pr_hotfix_no_requeue_after_ga(self):
         """PR queued pre-GA must not be re-queued after the GA tag is pushed.
 

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -540,6 +540,33 @@ class QuickTest(unittest.TestCase):
         fixver = ['9.5.3', '10.0.1', '10.1.0']
         self.finalize_cascade(branches, tags, destination, fixver)
 
+    def test_phantom_hotfix_hfrev_updated_by_ga_tag(self):
+        """Phantom hotfix hfrev and version must be updated by update_versions.
+
+        When hotfix/10.0.0 is stored as a phantom (non-hotfix PR destination),
+        update_versions() must still advance its hfrev when GA tags arrive.
+        Without the fix the phantom's hfrev stays at 0 forever, exposing
+        stale data to any future caller that reads .hfrev or .version.
+        """
+        my_dst = gwfb.branch_factory(FakeGitRepo(), 'development/10')
+        cascade = gwfb.BranchCascade()
+        for name in ('development/9.5', 'hotfix/10.0.0', 'development/10'):
+            cascade.add_branch(gwfb.branch_factory(FakeGitRepo(), name),
+                               my_dst)
+
+        self.assertEqual(len(cascade._phantom_hotfixes), 1)
+        phantom = cascade._phantom_hotfixes[0]
+
+        # Pre-GA: no 10.0.0.X tags — hfrev must remain 0
+        cascade.update_versions('9.5.2')
+        self.assertEqual(phantom.hfrev, 0)
+        self.assertEqual(phantom.version, '10.0.0.0')
+
+        # GA tag 10.0.0.0 lands — phantom hfrev must advance to 1
+        cascade.update_versions('10.0.0.0')
+        self.assertEqual(phantom.hfrev, 1)        # fails without the fix
+        self.assertEqual(phantom.version, '10.0.0.1')
+
     def test_branch_cascade_target_three_digit_dev(self):
         """Test cascade targeting three-digit development branch"""
         destination = 'development/4.3.17'

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -514,6 +514,32 @@ class QuickTest(unittest.TestCase):
         tags = ['9.5.0', '9.5.1', '10.0.0.0']
         self.finalize_cascade(branches, tags, destination, fixver)
 
+    def test_branch_cascade_2digit_with_pre_ga_hotfix(self):
+        """2-digit dev branches coexisting with pre-GA hotfix.
+
+        Scenario: dev/9.5, hotfix/10.0.0 (pre-GA), dev/10.0, dev/10.
+        Note: in the rename-based workflow hotfix/10.0.0 replaces dev/10.0;
+        but both can coexist when the hotfix is branched off before GA.
+        """
+        destination = 'development/9.5'
+        branches = OrderedDict({
+            1: {'name': 'development/9.5', 'ignore': False},
+            2: {'name': 'hotfix/10.0.0', 'ignore': True},
+            3: {'name': 'development/10.0', 'ignore': False},
+            4: {'name': 'development/10', 'ignore': False},
+        })
+        # Pre-GA: no tags for 10.x yet
+        # dev/10.0 targets 10.0.0, dev/10 targets 10.1.0 (latest_minor=0)
+        tags = ['9.5.2']
+        fixver = ['9.5.3', '10.0.0', '10.1.0']
+        self.finalize_cascade(branches, tags, destination, fixver)
+
+        # Post-GA: tag 10.0.0.0 advances dev/10.0 to target 10.0.1
+        # dev/10 still targets 10.1.0 (latest_minor=0 unchanged)
+        tags = ['9.5.2', '10.0.0.0']
+        fixver = ['9.5.3', '10.0.1', '10.1.0']
+        self.finalize_cascade(branches, tags, destination, fixver)
+
     def test_branch_cascade_target_three_digit_dev(self):
         """Test cascade targeting three-digit development branch"""
         destination = 'development/4.3.17'

--- a/bert_e/tests/unit/test_jira.py
+++ b/bert_e/tests/unit/test_jira.py
@@ -1,0 +1,121 @@
+"""Unit tests for check_fix_versions in jira.py.
+
+Covers the pre-GA hotfix dual-acceptance rule:
+  - When the hotfix branch has no GA tag yet (hfrev == 0 → target ends
+    in ".0"), both the 4-digit form ("10.0.0.0") AND the 3-digit base
+    ("10.0.0") must be accepted.
+  - Once the GA tag is pushed (hfrev advances to 1 → target becomes
+    "10.0.0.1"), only the exact 4-digit version is accepted again.
+"""
+import pytest
+from types import SimpleNamespace
+
+from bert_e import exceptions
+from bert_e.workflow.gitwaterflow.jira import check_fix_versions
+
+
+def _make_issue(*version_names):
+    versions = [SimpleNamespace(name=v) for v in version_names]
+    return SimpleNamespace(
+        key='TEST-00001',
+        fields=SimpleNamespace(fixVersions=versions),
+    )
+
+
+def _make_job(*target_versions):
+    cascade = SimpleNamespace(target_versions=list(target_versions))
+    git = SimpleNamespace(cascade=cascade)
+    return SimpleNamespace(git=git, active_options=[])
+
+
+# ---------------------------------------------------------------------------
+# Pre-GA hotfix: target ends in ".0" (hfrev == 0, no GA tag yet)
+# ---------------------------------------------------------------------------
+
+def test_pre_ga_hotfix_accepts_four_digit_version():
+    """Jira with '10.0.0.0' is accepted for pre-GA hotfix/10.0.0."""
+    check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.0.0'))
+
+
+def test_pre_ga_hotfix_accepts_three_digit_version():
+    """Jira with '10.0.0' is accepted for pre-GA hotfix/10.0.0 (no GA tag)."""
+    check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.0'))
+
+
+def test_pre_ga_hotfix_accepts_three_digit_among_others():
+    """Jira with '10.0.0' among other versions is still accepted."""
+    check_fix_versions(
+        _make_job('10.0.0.0'),
+        _make_issue('9.5.3', '10.0.0', '11.0.0'),
+    )
+
+
+def test_pre_ga_hotfix_rejects_wrong_version():
+    """Unrelated version is rejected for pre-GA hotfix/10.0.0."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.0'), _make_issue('9.5.0'))
+
+
+def test_pre_ga_hotfix_rejects_empty_versions():
+    """No fix version in Jira is rejected for pre-GA hotfix/10.0.0."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.0'), _make_issue())
+
+
+def test_pre_ga_hotfix_rejects_next_micro():
+    """'10.0.1' is not a valid substitute for pre-GA '10.0.0.0'."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.1'))
+
+
+# ---------------------------------------------------------------------------
+# Post-GA hotfix: target does NOT end in ".0" (hfrev >= 1, GA tag exists)
+# ---------------------------------------------------------------------------
+
+def test_post_ga_hotfix_accepts_correct_4digit():
+    """'10.0.0.1' in Jira is accepted for post-GA hotfix (hfrev=1)."""
+    check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0.1'))
+
+
+def test_post_ga_hotfix_rejects_3digit_base():
+    """'10.0.0' is NOT accepted once GA tag exists (target is '10.0.0.1')."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0'))
+
+
+def test_post_ga_hotfix_rejects_pre_ga_4digit():
+    """'10.0.0.0' is NOT accepted once GA tag exists (target is '10.0.0.1')."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0.0'))
+
+
+def test_post_ga_second_hotfix():
+    """'10.0.0.2' in Jira is accepted for second post-GA hotfix (hfrev=2)."""
+    check_fix_versions(_make_job('10.0.0.2'), _make_issue('10.0.0.2'))
+
+
+def test_post_ga_hotfix_rejects_lower_hfrev():
+    """'10.0.0.1' is NOT accepted when target is '10.0.0.2'."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.2'), _make_issue('10.0.0.1'))
+
+
+# ---------------------------------------------------------------------------
+# Regular dev-branch PR (not hotfix) — pre-existing behaviour unchanged
+# ---------------------------------------------------------------------------
+
+def test_dev_branch_accepts_matching_versions():
+    """Standard 3-digit dev-branch version check still works."""
+    check_fix_versions(
+        _make_job('4.3.19', '5.1.4'),
+        _make_issue('4.3.19', '5.1.4'),
+    )
+
+
+def test_dev_branch_rejects_mismatch():
+    """Wrong versions for a dev-branch PR are still rejected."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(
+            _make_job('4.3.19', '5.1.4'),
+            _make_issue('4.3.18', '5.1.4'),
+        )

--- a/bert_e/tests/unit/test_jira.py
+++ b/bert_e/tests/unit/test_jira.py
@@ -1,11 +1,13 @@
 """Unit tests for check_fix_versions in jira.py.
 
-Covers the pre-GA hotfix dual-acceptance rule:
-  - When the hotfix branch has no GA tag yet (hfrev == 0 → target ends
-    in ".0"), both the 4-digit form ("10.0.0.0") AND the 3-digit base
-    ("10.0.0") must be accepted.
-  - Once the GA tag is pushed (hfrev advances to 1 → target becomes
-    "10.0.0.1"), only the exact 4-digit version is accepted again.
+Rules:
+- Hotfix branch PRs require the exact 4-digit fix version in Jira
+  (e.g. "10.0.0.0" pre-GA, "10.0.0.1" first post-GA hotfix, …).
+  3-digit aliases (e.g. "10.0.0") are NOT accepted.
+- Development-branch PRs may have an extra 4-digit "X.Y.Z.0" entry in
+  the ticket when a pre-GA hotfix branch exists alongside the waterflow.
+  That entry is consumed by the separate cherry-pick PR to the hotfix
+  branch and must not cause the dev-branch check to fail.
 """
 import pytest
 from types import SimpleNamespace
@@ -22,38 +24,28 @@ def _make_issue(*version_names):
     )
 
 
-def _make_job(*target_versions):
-    cascade = SimpleNamespace(target_versions=list(target_versions))
+def _make_job(*target_versions, phantom_hotfix_versions=None):
+    cascade = SimpleNamespace(
+        target_versions=list(target_versions),
+        phantom_hotfix_versions=phantom_hotfix_versions or set(),
+    )
     git = SimpleNamespace(cascade=cascade)
     return SimpleNamespace(git=git, active_options=[])
 
 
 # ---------------------------------------------------------------------------
-# Pre-GA hotfix: target ends in ".0" (hfrev == 0, no GA tag yet)
+# Hotfix branch PRs — exact 4-digit version required
 # ---------------------------------------------------------------------------
 
 def test_pre_ga_hotfix_accepts_four_digit_version():
-    """Jira with '10.0.0.0' is accepted for pre-GA hotfix/10.0.0."""
+    """'10.0.0.0' in Jira is accepted for pre-GA hotfix/10.0.0."""
     check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.0.0'))
 
 
-def test_pre_ga_hotfix_accepts_three_digit_version():
-    """Jira with '10.0.0' is accepted for pre-GA hotfix/10.0.0 (no GA tag)."""
-    check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.0'))
-
-
-def test_pre_ga_hotfix_accepts_three_digit_among_others():
-    """Jira with '10.0.0' among other versions is still accepted."""
-    check_fix_versions(
-        _make_job('10.0.0.0'),
-        _make_issue('9.5.3', '10.0.0', '11.0.0'),
-    )
-
-
-def test_pre_ga_hotfix_rejects_wrong_version():
-    """Unrelated version is rejected for pre-GA hotfix/10.0.0."""
+def test_pre_ga_hotfix_rejects_three_digit_version():
+    """'10.0.0' alone is NOT accepted — only 4-digit '10.0.0.0' is valid."""
     with pytest.raises(exceptions.IncorrectFixVersion):
-        check_fix_versions(_make_job('10.0.0.0'), _make_issue('9.5.0'))
+        check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.0'))
 
 
 def test_pre_ga_hotfix_rejects_empty_versions():
@@ -62,31 +54,27 @@ def test_pre_ga_hotfix_rejects_empty_versions():
         check_fix_versions(_make_job('10.0.0.0'), _make_issue())
 
 
-def test_pre_ga_hotfix_rejects_next_micro():
-    """'10.0.1' is not a valid substitute for pre-GA '10.0.0.0'."""
+def test_pre_ga_hotfix_rejects_wrong_version():
+    """Unrelated version is rejected for pre-GA hotfix/10.0.0."""
     with pytest.raises(exceptions.IncorrectFixVersion):
-        check_fix_versions(_make_job('10.0.0.0'), _make_issue('10.0.1'))
+        check_fix_versions(_make_job('10.0.0.0'), _make_issue('9.5.0'))
 
-
-# ---------------------------------------------------------------------------
-# Post-GA hotfix: target does NOT end in ".0" (hfrev >= 1, GA tag exists)
-# ---------------------------------------------------------------------------
 
 def test_post_ga_hotfix_accepts_correct_4digit():
     """'10.0.0.1' in Jira is accepted for post-GA hotfix (hfrev=1)."""
     check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0.1'))
 
 
-def test_post_ga_hotfix_rejects_3digit_base():
-    """'10.0.0' is NOT accepted once GA tag exists (target is '10.0.0.1')."""
-    with pytest.raises(exceptions.IncorrectFixVersion):
-        check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0'))
-
-
-def test_post_ga_hotfix_rejects_pre_ga_4digit():
+def test_post_ga_hotfix_rejects_pre_ga_version():
     """'10.0.0.0' is NOT accepted once GA tag exists (target is '10.0.0.1')."""
     with pytest.raises(exceptions.IncorrectFixVersion):
         check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0.0'))
+
+
+def test_post_ga_hotfix_rejects_3digit_base():
+    """'10.0.0' is NOT accepted for post-GA hotfix (target is '10.0.0.1')."""
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(_make_job('10.0.0.1'), _make_issue('10.0.0'))
 
 
 def test_post_ga_second_hotfix():
@@ -94,14 +82,50 @@ def test_post_ga_second_hotfix():
     check_fix_versions(_make_job('10.0.0.2'), _make_issue('10.0.0.2'))
 
 
-def test_post_ga_hotfix_rejects_lower_hfrev():
-    """'10.0.0.1' is NOT accepted when target is '10.0.0.2'."""
+# ---------------------------------------------------------------------------
+# Development-branch PRs — phantom hotfix version excluded from check
+# ---------------------------------------------------------------------------
+
+def test_dev_pr_phantom_hotfix_excluded_from_check():
+    """Ticket with 9.5.3 + 10.0.0.0 + 10.1.0 passes the dev/9.5 PR check.
+
+    The 10.0.0.0 entry belongs to the pre-GA hotfix branch and is consumed
+    by the separate cherry-pick PR.  It must not cause a mismatch here.
+    """
+    job = _make_job('9.5.3', '10.1.0',
+                    phantom_hotfix_versions={'10.0.0.0'})
+    issue = _make_issue('9.5.3', '10.0.0.0', '10.1.0')
+    check_fix_versions(job, issue)  # must not raise
+
+
+def test_dev_pr_phantom_hotfix_still_requires_all_dev_versions():
+    """Missing dev version still fails even when phantom is excluded."""
+    job = _make_job('9.5.3', '10.1.0',
+                    phantom_hotfix_versions={'10.0.0.0'})
+    issue = _make_issue('9.5.3', '10.0.0.0')  # missing 10.1.0
     with pytest.raises(exceptions.IncorrectFixVersion):
-        check_fix_versions(_make_job('10.0.0.2'), _make_issue('10.0.0.1'))
+        check_fix_versions(job, issue)
+
+
+def test_dev_pr_no_phantom_rejects_unexpected_4digit_version():
+    """Without a phantom hotfix, X.Y.Z.0 in the ticket causes a mismatch."""
+    job = _make_job('9.5.3', '10.1.0',
+                    phantom_hotfix_versions=set())
+    issue = _make_issue('9.5.3', '10.0.0.0', '10.1.0')
+    with pytest.raises(exceptions.IncorrectFixVersion):
+        check_fix_versions(job, issue)
+
+
+def test_dev_pr_without_hotfix_version_passes():
+    """Dev PR still passes when the ticket has exactly the dev versions."""
+    job = _make_job('9.5.3', '10.1.0',
+                    phantom_hotfix_versions={'10.0.0.0'})
+    issue = _make_issue('9.5.3', '10.1.0')
+    check_fix_versions(job, issue)  # must not raise
 
 
 # ---------------------------------------------------------------------------
-# Regular dev-branch PR (not hotfix) — pre-existing behaviour unchanged
+# Regular dev-branch PR (no phantom hotfixes) — pre-existing behaviour
 # ---------------------------------------------------------------------------
 
 def test_dev_branch_accepts_matching_versions():

--- a/bert_e/tests/unit/test_queueing.py
+++ b/bert_e/tests/unit/test_queueing.py
@@ -1,0 +1,61 @@
+"""Unit tests for the queueing module."""
+from types import SimpleNamespace
+
+from bert_e.workflow.gitwaterflow.branches import (
+    DevelopmentBranch, HotfixBranch
+)
+from bert_e.workflow.gitwaterflow.queueing import get_queue_integration_branch
+
+
+class _FakeRepo:
+    """Minimal git-repo stub that satisfies GWFBranch.__init__."""
+    def __init__(self):
+        self._url = ''
+        self._remote_branches = {}
+
+    def cmd(self, *args, **kwargs):
+        return ''
+
+
+def _make_job(dst_branch, src_branch='bugfix/TEST-00001'):
+    """Return a minimal job stub for get_queue_integration_branch."""
+    cascade = SimpleNamespace(dst_branches=[dst_branch])
+    git = SimpleNamespace(cascade=cascade, repo=_FakeRepo())
+    return SimpleNamespace(git=git,
+                           pull_request=SimpleNamespace(src_branch=src_branch))
+
+
+def test_get_queue_integration_branch_hotfix_uses_dst_version():
+    """HotfixBranch destination — queue name must embed dst_branch.version."""
+    dst = HotfixBranch(_FakeRepo(), 'hotfix/10.0.0')  # hfrev=0 → '10.0.0.0'
+    wbranch = SimpleNamespace(version='10.0.0.0')
+
+    result = get_queue_integration_branch(_make_job(dst), pr_id=1,
+                                          wbranch=wbranch)
+    assert result.name == 'q/w/1/10.0.0.0/bugfix/TEST-00001'
+
+
+def test_get_queue_integration_branch_dev_uses_wbranch_version():
+    """DevelopmentBranch destination — queue name must embed wbranch.version.
+
+    This is the regression test for Risk 3: the old guard was ``hfrev >= 0``
+    which would *incorrectly* activate for any non-hotfix branch whose hfrev
+    was patched to 0.  The correct guard is ``isinstance(..., HotfixBranch)``.
+
+    Without the fix (hfrev >= 0): hfrev=0 on a DevelopmentBranch would make
+    the condition True, so the queue name would use dst.version ('10') instead
+    of wbranch.version ('10.1') — the assertion below would then fail.
+    """
+    dst = DevelopmentBranch(_FakeRepo(), 'development/10')
+    # Artificially set hfrev=0 to expose the old `hfrev >= 0` bug path.
+    dst.hfrev = 0
+
+    # wbranch.version intentionally differs from dst.version to make the
+    # wrong-branch-name visible.
+    wbranch = SimpleNamespace(version='10.1')
+    result = get_queue_integration_branch(_make_job(dst), pr_id=1,
+                                          wbranch=wbranch)
+
+    # Must be based on wbranch.version, not dst.version
+    assert '/10.1/' in result.name
+    assert result.name == 'q/w/1/10.1/bugfix/TEST-00001'

--- a/bert_e/workflow/git_utils.py
+++ b/bert_e/workflow/git_utils.py
@@ -139,4 +139,5 @@ def clone_git_repo(job):
     repo.config('user.email', job.settings.robot_email)
     repo.config('user.name', job.settings.robot)
     repo.config('merge.renameLimit', '999999')
+    repo.config('merge.ff', 'true')
     return repo

--- a/bert_e/workflow/gitwaterflow/__init__.py
+++ b/bert_e/workflow/gitwaterflow/__init__.py
@@ -225,6 +225,7 @@ def _handle_pull_request(job: PullRequestJob):
         raise messages.Queued(
             branches=job.git.cascade.dst_branches,
             ignored=job.git.cascade.ignored_branches,
+            pending_hotfixes=job.git.cascade.pending_hotfix_branches,
             issue=job.git.src_branch.jira_issue_key,
             author=job.pull_request.author_display_name,
             active_options=job.active_options)
@@ -242,6 +243,7 @@ def _handle_pull_request(job: PullRequestJob):
         raise messages.SuccessMessage(
             branches=job.git.cascade.dst_branches,
             ignored=job.git.cascade.ignored_branches,
+            pending_hotfixes=job.git.cascade.pending_hotfix_branches,
             issue=job.git.src_branch.jira_issue_key,
             author=job.pull_request.author_display_name,
             active_options=job.active_options)

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -1018,6 +1018,17 @@ class BranchCascade(object):
                                                      hf_branch.micro,
                                                      hf_branch.hfrev)
 
+        # Also update phantom hotfixes (stored outside _cascade for dev PRs).
+        # They are only consumed for their .minor today, but keeping .hfrev
+        # and .version current prevents stale data surprises in future callers.
+        for phantom in self._phantom_hotfixes:
+            if (phantom.major == major and phantom.minor == minor and
+                    phantom.micro == micro):
+                phantom.hfrev = max(hfrev + 1, phantom.hfrev)
+                phantom.version = '%d.%d.%d.%d' % (
+                    phantom.major, phantom.minor,
+                    phantom.micro, phantom.hfrev)
+
         if micro_branch is not None and \
            ([micro_branch.major, micro_branch.minor,
              micro_branch.micro] == [major, minor, micro]):

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -875,6 +875,34 @@ class BranchCascade(object):
         # hotfix branches stored outside cascade for version calc only
         self._phantom_hotfixes = []
 
+    @property
+    def pending_hotfix_branches(self):
+        """Hotfix branches stored as phantoms that require a separate PR.
+
+        When a PR targets a development branch and a hotfix branch exists
+        for the same major version (pre-GA), the hotfix is kept outside the
+        cascade so version calculations stay correct without making it an
+        implicit merge target.  The author should open a separate PR to
+        each of these hotfix branches.
+        """
+        return list(self._phantom_hotfixes)
+
+    @property
+    def phantom_hotfix_versions(self):
+        """4-digit version strings of pre-GA phantom hotfix branches.
+
+        Pre-GA hotfix branches (hfrev == 0) produce an X.Y.Z.0 version that
+        matches the vfilter used in check_fix_versions.  When such a version
+        appears in a Jira ticket alongside the dev-branch versions, it must
+        not be counted against the dev-branch PR — it is consumed by the
+        separate cherry-pick PR to the hotfix branch.
+        Post-GA hotfix versions (X.Y.Z.1, X.Y.Z.2, …) don't match vfilter
+        so they never interfere with the dev-branch check.
+        """
+        return {hf.version
+                for hf in self._phantom_hotfixes
+                if hf.hfrev == 0}
+
     def build(self, repo, dst_branch=None):
         flat_branches = set()
         for prefix in ['development', 'hotfix']:

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -187,6 +187,12 @@ class HotfixBranch(GWFBranch):
     cascade_consumer = True
     can_be_destination = True
     allow_prefixes = FeatureBranch.all_prefixes
+    hfrev = 0  # pre-GA default: no tags yet (overrides GWFBranch.hfrev = -1)
+
+    def __init__(self, repo, name):
+        super().__init__(repo, name)
+        # Default version includes .0 until update_versions() sees a tag
+        self.version = '%d.%d.%d.%d' % (self.major, self.minor, self.micro, 0)
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__ and
@@ -635,8 +641,9 @@ class QueueCollection(object):
             qint = self._queues[version][QueueIntegrationBranch]
             if qint:
                 qint = qint[0]
+                tip = qint.get_latest_commit()
                 status = self.bbrepo.get_build_status(
-                    qint.get_latest_commit(),
+                    tip,
                     self.build_key
                 )
                 if status == 'FAILED':
@@ -858,6 +865,7 @@ class BranchCascade(object):
         self.ignored_branches = []  # store branch names (easier sort)
         self.target_versions = []
         self._merge_paths = []
+        self._phantom_hotfixes = []  # hotfix branches stored outside cascade for version calc
 
     def build(self, repo, dst_branch=None):
         flat_branches = set()
@@ -927,7 +935,15 @@ class BranchCascade(object):
                    branch.micro != dst_branch.micro:
                     # this is not the hotfix branch we want to add
                     return
+            elif not dst_branch:
+                # No destination context (e.g. queue management) — skip
+                return
             else:
+                # Non-hotfix destination: store the hotfix as a phantom so
+                # _update_major_versions() can advance development/<major>'s
+                # latest_minor past the hotfix line (e.g. dev/10 → 10.1.0
+                # once hotfix/10.0.0 exists) without polluting the cascade.
+                self._phantom_hotfixes.append(branch)
                 return
 
         # Create key based on full version tuple
@@ -1071,14 +1087,21 @@ class BranchCascade(object):
                 major_branch: DevelopmentBranch = branch_set[DevelopmentBranch]
                 major = version_tuple[0]
 
-                # Find all minor versions for this major
+                # Find all minor versions for this major from the cascade
                 minors = [
-                    version_tuple[1] for version_tuple in self._cascade.keys()
-                    if (len(version_tuple) >= 2 and
-                        version_tuple[0] == major and
-                        version_tuple[1] is not None)
+                    vt[1] for vt in self._cascade.keys()
+                    if (len(vt) >= 2 and vt[0] == major and
+                        vt[1] is not None)
                 ]
                 minors.append(major_branch.latest_minor)
+
+                # Also include phantom hotfix branches (stored separately to
+                # avoid corrupting the cascade) so that e.g. hotfix/10.0.0
+                # advances dev/10's latest_minor to 0 even without a tag.
+                minors.extend(
+                    hf.minor for hf in self._phantom_hotfixes
+                    if hf.major == major
+                )
 
                 major_branch.latest_minor = max(minors)
             elif len(version_tuple) == 2 and version_tuple[1] is not None:
@@ -1237,8 +1260,9 @@ class BranchCascade(object):
                     # For hotfix destinations, ignore all dev branches
                     self.ignored_branches.append(dev_branch.name)
                     branch_set[DevelopmentBranch] = None
-            # Handle hotfix branches
-            if hf_branch:
+            # Handle hotfix branches — only a merge destination for hotfix PRs;
+            # for dev PRs they are phantom entries used only for version tracking
+            if hf_branch and dst_hf:
                 self.dst_branches.append(hf_branch)
 
         # Clean up the cascade by removing keys with no branches

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -865,7 +865,8 @@ class BranchCascade(object):
         self.ignored_branches = []  # store branch names (easier sort)
         self.target_versions = []
         self._merge_paths = []
-        self._phantom_hotfixes = []  # hotfix branches stored outside cascade for version calc
+        # hotfix branches stored outside cascade for version calc only
+        self._phantom_hotfixes = []
 
     def build(self, repo, dst_branch=None):
         flat_branches = set()
@@ -1260,8 +1261,9 @@ class BranchCascade(object):
                     # For hotfix destinations, ignore all dev branches
                     self.ignored_branches.append(dev_branch.name)
                     branch_set[DevelopmentBranch] = None
-            # Handle hotfix branches — only a merge destination for hotfix PRs;
-            # for dev PRs they are phantom entries used only for version tracking
+            # Handle hotfix branches — only a merge destination for
+            # hotfix PRs; for dev PRs they are phantom entries used
+            # only for version tracking
             if hf_branch and dst_hf:
                 self.dst_branches.append(hf_branch)
 

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -829,12 +829,19 @@ class QueueCollection(object):
         return pr_hf_ids + pr_non_hf_ids
 
     def has_version_queued_prs(self, version):
-        # delete_branch() may call this property with a four numbers version
-        # finished by -1, so we can not rely on this last number to match.
-        if len(version) == 4 and version[3] == -1:
+        # delete_branch() may call this with a version whose hfrev has not
+        # been resolved by update_versions (hfrev == -1 legacy, or hfrev == 0
+        # when branch_factory is called without a cascade).  In that case we
+        # must not rely on the last number to match.
+        if len(version) == 4 and version[3] in (-1, 0):
+            # Try exact match first (covers true pre-GA queues where hfrev=0)
+            exact = self._queues.get(version, {}).get(QueueIntegrationBranch)
+            if exact is not None:
+                return True
+            # Fallback: prefix match (covers post-GA where update_versions
+            # advanced hfrev but branch_factory still returned hfrev=0)
             for queue_version in self._queues.keys():
                 if len(queue_version) == 4 and \
-                   len(version) == 4 and \
                    queue_version[:3] == version[:3]:
                     queued_pr = self._queues.get(queue_version)
                     if queued_pr is not None and \

--- a/bert_e/workflow/gitwaterflow/jira.py
+++ b/bert_e/workflow/gitwaterflow/jira.py
@@ -25,6 +25,7 @@ from jira.exceptions import JIRAError
 
 from bert_e import exceptions
 from bert_e.lib import jira as jira_api
+from ..pr_utils import notify_user
 from .utils import bypass_jira_check
 
 
@@ -55,6 +56,7 @@ def jira_checks(job):
 
     if not job.settings.disable_version_checks:
         check_fix_versions(job, issue)
+        _notify_pending_hotfix_if_needed(job, issue)
 
 
 def get_jira_issue(job):
@@ -189,3 +191,26 @@ def check_fix_versions(job, issue):
                 expect_versions=sorted(expected_versions),
                 active_options=job.active_options
             )
+
+
+def _notify_pending_hotfix_if_needed(job, issue):
+    """Post a one-time reminder when the ticket carries a pre-GA hotfix
+    fix version (X.Y.Z.0) so the developer knows to open a cherry-pick PR
+    to the corresponding hotfix branch.
+
+    This is an informational message: it is posted at most once per PR
+    (dont_repeat_if_in_history = NEVER_REPEAT) and never blocks the flow.
+    """
+    phantom_versions = job.git.cascade.phantom_hotfix_versions
+    if not phantom_versions:
+        return
+    issue_versions = {v.name for v in issue.fields.fixVersions}
+    matching = sorted(phantom_versions & issue_versions)
+    if not matching:
+        return
+    reminder = exceptions.PendingHotfixVersionReminder(
+        issue=issue,
+        hotfix_versions=matching,
+        active_options=job.active_options,
+    )
+    notify_user(job.settings, job.pull_request, reminder)

--- a/bert_e/workflow/gitwaterflow/jira.py
+++ b/bert_e/workflow/gitwaterflow/jira.py
@@ -165,10 +165,10 @@ def check_fix_versions(job, issue):
             hf_target = target_version
 
     if hf_target:
-        # Pre-GA: the hotfix branch has no tag yet (hfrev == 0 → target ends
+        # Pre-GA: the hotfix branch has no tag yet (hfrev == 0, target ends
         # in ".0").  The Jira project may not have a ".0" release entry yet,
-        # so also accept the 3-digit base version (e.g. "10.0.0" for "10.0.0.0").
-        # Once the GA tag is pushed hfrev advances to 1, the target becomes
+        # so also accept the 3-digit base (e.g. "10.0.0" for "10.0.0.0").
+        # Once GA tag is pushed hfrev advances to 1, target becomes
         # "10.0.0.1", and only that exact version is accepted again.
         accepted = {hf_target}
         if hf_target.endswith('.0'):

--- a/bert_e/workflow/gitwaterflow/jira.py
+++ b/bert_e/workflow/gitwaterflow/jira.py
@@ -165,25 +165,27 @@ def check_fix_versions(job, issue):
             hf_target = target_version
 
     if hf_target:
-        # Pre-GA: the hotfix branch has no tag yet (hfrev == 0, target ends
-        # in ".0").  The Jira project may not have a ".0" release entry yet,
-        # so also accept the 3-digit base (e.g. "10.0.0" for "10.0.0.0").
-        # Once GA tag is pushed hfrev advances to 1, target becomes
-        # "10.0.0.1", and only that exact version is accepted again.
-        accepted = {hf_target}
-        if hf_target.endswith('.0'):
-            accepted.add(hf_target[:-2])
-        if not (accepted & issue_versions):
+        # Hotfix PR: the ticket must carry the exact 4-digit target version
+        # (e.g. "10.0.0.0" pre-GA, "10.0.0.1" post-GA first hotfix, …).
+        # 3-digit aliases are no longer accepted — a 4-digit entry makes it
+        # unambiguous whether the branch is still pre-GA or an actual hotfix.
+        if hf_target not in issue_versions:
             raise exceptions.IncorrectFixVersion(
                 issue=issue,
                 issue_versions=sorted(issue_versions),
-                expect_versions=sorted(accepted),
+                expect_versions=sorted(expected_versions),
                 active_options=job.active_options
             )
-    elif checked_versions != expected_versions:
-        raise exceptions.IncorrectFixVersion(
-            issue=issue,
-            issue_versions=sorted(issue_versions),
-            expect_versions=sorted(expected_versions),
-            active_options=job.active_options
-        )
+    else:
+        # Development-branch PR: versions that belong to a phantom hotfix
+        # branch (pre-GA hotfix/X.Y.Z stored outside the cascade) will be
+        # consumed by the separate cherry-pick PR to that hotfix branch.
+        # Strip them so they don't cause a spurious mismatch here.
+        checked_versions -= job.git.cascade.phantom_hotfix_versions
+        if checked_versions != expected_versions:
+            raise exceptions.IncorrectFixVersion(
+                issue=issue,
+                issue_versions=sorted(issue_versions),
+                expect_versions=sorted(expected_versions),
+                active_options=job.active_options
+            )

--- a/bert_e/workflow/gitwaterflow/jira.py
+++ b/bert_e/workflow/gitwaterflow/jira.py
@@ -165,11 +165,19 @@ def check_fix_versions(job, issue):
             hf_target = target_version
 
     if hf_target:
-        if hf_target not in issue_versions:
+        # Pre-GA: the hotfix branch has no tag yet (hfrev == 0 → target ends
+        # in ".0").  The Jira project may not have a ".0" release entry yet,
+        # so also accept the 3-digit base version (e.g. "10.0.0" for "10.0.0.0").
+        # Once the GA tag is pushed hfrev advances to 1, the target becomes
+        # "10.0.0.1", and only that exact version is accepted again.
+        accepted = {hf_target}
+        if hf_target.endswith('.0'):
+            accepted.add(hf_target[:-2])
+        if not (accepted & issue_versions):
             raise exceptions.IncorrectFixVersion(
                 issue=issue,
                 issue_versions=sorted(issue_versions),
-                expect_versions=sorted(expected_versions),
+                expect_versions=sorted(accepted),
                 active_options=job.active_options
             )
     elif checked_versions != expected_versions:

--- a/bert_e/workflow/gitwaterflow/queueing.py
+++ b/bert_e/workflow/gitwaterflow/queueing.py
@@ -24,8 +24,8 @@ from bert_e.lib import git
 from ..git_utils import clone_git_repo, consecutive_merge, robust_merge, push
 from ..pr_utils import notify_user
 from .branches import (BranchCascade, DevelopmentBranch, GWFBranch,
-                       IntegrationBranch, QueueBranch, QueueCollection,
-                       QueueIntegrationBranch, branch_factory,
+                       HotfixBranch, IntegrationBranch, QueueBranch,
+                       QueueCollection, QueueIntegrationBranch, branch_factory,
                        build_queue_collection)
 from .integration import get_integration_branches
 from typing import List
@@ -107,7 +107,7 @@ def get_queue_integration_branch(job, pr_id, wbranch: IntegrationBranch
     """Get the q/w/pr_id/x.y/* branch corresponding to a w/x.y/* branch."""
     wbranch_version = None
     if len(job.git.cascade.dst_branches) == 1 and \
-       job.git.cascade.dst_branches[0].hfrev >= 0:
+       isinstance(job.git.cascade.dst_branches[0], HotfixBranch):
         wbranch_version = job.git.cascade.dst_branches[0].version
     else:
         wbranch_version = wbranch.version

--- a/bert_e/workflow/gitwaterflow/queueing.py
+++ b/bert_e/workflow/gitwaterflow/queueing.py
@@ -126,9 +126,22 @@ def already_in_queue(job, wbranches):
 
     """
     pr_id = job.pull_request.id
-    return any(
-        get_queue_integration_branch(job, pr_id, w).exists() for w in wbranches
-    )
+    if any(get_queue_integration_branch(job, pr_id, w).exists()
+           for w in wbranches):
+        return True
+    # Fallback for hotfix branches: the hfrev embedded in the queue branch
+    # name may have changed since the PR was queued (pre-GA → post-GA
+    # transition).  Scan by major.minor.micro prefix to detect the existing
+    # queue branch regardless of which hfrev was in effect when first queued.
+    if (len(job.git.cascade.dst_branches) == 1 and
+            isinstance(job.git.cascade.dst_branches[0], HotfixBranch)):
+        dst = job.git.cascade.dst_branches[0]
+        prefix = 'origin/q/w/%d/%d.%d.%d.' % (
+            pr_id, dst.major, dst.minor, dst.micro)
+        if job.git.repo.cmd(
+                'git branch -r --list %s*' % prefix).strip():
+            return True
+    return False
 
 
 def add_to_queue(job, wbranches):

--- a/bert_e/workflow/gitwaterflow/queueing.py
+++ b/bert_e/workflow/gitwaterflow/queueing.py
@@ -217,6 +217,7 @@ def close_queued_pull_request(job, pr_id, cascade):
             job.settings, pull_request, exceptions.SuccessMessage(
                 branches=target_branches,
                 ignored=job.git.cascade.ignored_branches,
+                pending_hotfixes=job.git.cascade.pending_hotfix_branches,
                 issue=src.jira_issue_key,
                 author=pull_request.author_display_name,
                 active_options=[])

--- a/bert_e/workflow/gitwaterflow/queueing.py
+++ b/bert_e/workflow/gitwaterflow/queueing.py
@@ -107,7 +107,7 @@ def get_queue_integration_branch(job, pr_id, wbranch: IntegrationBranch
     """Get the q/w/pr_id/x.y/* branch corresponding to a w/x.y/* branch."""
     wbranch_version = None
     if len(job.git.cascade.dst_branches) == 1 and \
-       job.git.cascade.dst_branches[0].hfrev > 0:
+       job.git.cascade.dst_branches[0].hfrev >= 0:
         wbranch_version = job.git.cascade.dst_branches[0].version
     else:
         wbranch_version = wbranch.version


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the versioning and cascade logic for hotfix and development branches, especially in pre-GA (General Availability) scenarios. The changes ensure that hotfix branches without a GA tag are handled correctly, development branches target the right versions when hotfixes exist, and the test suite covers these edge cases. Additionally, minor improvements to git configuration and quoting logic are included.

**Hotfix and Development Branch Cascade Logic Improvements:**

* Hotfix branches now default to version `x.y.z.0` before a GA tag exists, and this is reflected in the new `hfrev = 0` default and initialization logic in `HotfixBranch`, ensuring pre-GA hotfixes are versioned correctly.
* Development branches (e.g., `development/10`) now correctly advance their target version (e.g., to `10.1.0`) when a pre-GA hotfix branch (e.g., `hotfix/10.0.0`) exists, even if no GA tag is present. This is achieved by tracking "phantom" hotfixes for version calculation without including them in the actual cascade. [[1]](diffhunk://#diff-2f6e1179ed4541ba7239ae873ce6ad8cf45355d5dd9e02a2de9cad20b3b436faR868) [[2]](diffhunk://#diff-2f6e1179ed4541ba7239ae873ce6ad8cf45355d5dd9e02a2de9cad20b3b436faR938-R946) [[3]](diffhunk://#diff-2f6e1179ed4541ba7239ae873ce6ad8cf45355d5dd9e02a2de9cad20b3b436faL1074-R1105) [[4]](diffhunk://#diff-2f6e1179ed4541ba7239ae873ce6ad8cf45355d5dd9e02a2de9cad20b3b436faL1240-R1265)

**Test Suite Enhancements:**

* Added comprehensive tests for pre-GA hotfix and development branch scenarios, including: ensuring correct fix versioning for PRs targeting hotfix branches before GA, verifying development branches target the correct versions when pre-GA hotfixes exist, and handling mixed cascades with 2-digit and 3-digit development branches. [[1]](diffhunk://#diff-5c0d206b167ef78f6bc457ba29b9c02058cbdc8b7fbe7239f243b98f1e06590fR444-R447) [[2]](diffhunk://#diff-5c0d206b167ef78f6bc457ba29b9c02058cbdc8b7fbe7239f243b98f1e06590fR462-R516) [[3]](diffhunk://#diff-5c0d206b167ef78f6bc457ba29b9c02058cbdc8b7fbe7239f243b98f1e06590fR5961-R5982)

**Queue and Build Logic Adjustments:**

* Updated queue integration logic to allow hotfix branches with `hfrev >= 0` (pre-GA or post-GA) to use their version for the queue branch, ensuring correct queue branch naming and Jira fix version assignment.
* Fixed build status retrieval in the cascade logic to use the latest commit for accurate status checks.

**Other Improvements:**

* Switched from the deprecated `pipes.quote` to `shlex.quote` for shell quoting, improving compatibility and security.
* Configured git to always use fast-forward merges by default in `clone_git_repo`, ensuring consistent merge behavior.