### PR TITLE
Fix CI: add setuptools to resolve missing pkg_resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-WTF==1.2.2
 ItsDangerous==2.2.0
 Jinja2==3.1.5
 jira==2.0.0
+setuptools
 Markdown==2.6.11
 marshmallow==3.23.1
 MarkupSafe==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==1.2.2
 ItsDangerous==2.2.0
 Jinja2==3.1.5
 jira==2.0.0
-setuptools
+setuptools<82
 Markdown==2.6.11
 marshmallow==3.23.1
 MarkupSafe==3.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -18,28 +18,28 @@ commands = flake8 bert_e/
 
 [testenv:utests]
 deps =
-  setuptools
+  setuptools<82
   pip==22.3.1
   pytest-cov==5.0.0
 commands = pytest bert_e/tests/unit/ {posargs}
 
 [testenv:tests-api-mock]
 deps =
-  setuptools
+  setuptools<82
   pip==22.3.1
   pytest-cov==5.0.0
 commands = pytest -v -k mock bert_e/tests/test_git_host.py {posargs}
 
 [testenv:tests-server]
 deps =
-  setuptools
+  setuptools<82
   pip==22.3.1
   pytest-cov==5.0.0
 commands = pytest bert_e/tests/test_server.py {posargs}
 
 [testenv:tests-noqueue]
 deps =
-  setuptools
+  setuptools<82
   pip==22.3.1
 passenv = CI
 commands =
@@ -59,7 +59,7 @@ commands =
 
 [testenv:tests]
 deps =
-  setuptools
+  setuptools<82
   pip==22.3.1
 passenv = CI
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -18,24 +18,28 @@ commands = flake8 bert_e/
 
 [testenv:utests]
 deps =
+  setuptools
   pip==22.3.1
   pytest-cov==5.0.0
 commands = pytest bert_e/tests/unit/ {posargs}
 
 [testenv:tests-api-mock]
 deps =
+  setuptools
   pip==22.3.1
   pytest-cov==5.0.0
 commands = pytest -v -k mock bert_e/tests/test_git_host.py {posargs}
 
 [testenv:tests-server]
 deps =
+  setuptools
   pip==22.3.1
   pytest-cov==5.0.0
 commands = pytest bert_e/tests/test_server.py {posargs}
 
 [testenv:tests-noqueue]
 deps =
+  setuptools
   pip==22.3.1
 passenv = CI
 commands =
@@ -55,6 +59,7 @@ commands =
 
 [testenv:tests]
 deps =
+  setuptools
   pip==22.3.1
 passenv = CI
 commands =


### PR DESCRIPTION
## Summary

- `pkg_resources` (provided by `setuptools`) is no longer pre-installed in the GitHub Actions runner environment
- The `jira` dependency uses it internally, causing an `ImportError` at collection time across all test jobs
- Add `setuptools` explicitly to `requirements.txt` and to each tox env that does not inherit the base `[testenv]` deps

## Test plan
- [ ] All CI jobs pass on this PR