### PR TITLE
Drop cherry-pick call-to-action from hotfix branch list in merge messages

### DIFF
--- a/bert_e/templates/queued.md
+++ b/bert_e/templates/queued.md
@@ -24,8 +24,8 @@ The following branches will **NOT** be impacted:
 {% endif %}
 
 {% if pending_hotfixes %}
-:warning: This pull request does **not** target the following hotfix
-branch(es). Please open a separate cherry-pick pull request to each:
+This pull request does not target the following hotfix branch(es) so they
+will be left untouched:
 
 {% for branch in pending_hotfixes -%}
 * `{{ branch.name }}`

--- a/bert_e/templates/successful_merge.md
+++ b/bert_e/templates/successful_merge.md
@@ -17,8 +17,8 @@ The following branches have **NOT** changed:
 {% endif %}
 
 {% if pending_hotfixes %}
-:warning: This pull request did **not** target the following hotfix
-branch(es). Please open a separate cherry-pick pull request to each:
+This pull request did not target the following hotfix branch(es) so they
+were left untouched:
 
 {% for branch in pending_hotfixes -%}
 * `{{ branch.name }}`


### PR DESCRIPTION
## Summary

- `queued.md` and `successful_merge.md` were telling developers to open a cherry-pick PR to **every** phantom hotfix branch in the cascade — which can be dozens of old, finished post-GA branches (e.g. scality/Integration#1426 showed 29 hotfix branches).
- The cherry-pick call to action is only correct when the Jira ticket explicitly carries a hotfix fix version (already handled by the separate `PendingHotfixVersionReminder` comment, code 223).
- The merge/queued messages now simply state the branches were not targeted and were left untouched, with no action required.

**Before:**
> :warning: This pull request did **not** target the following hotfix branch(es). Please open a separate cherry-pick pull request to each: ...

**After:**
> This pull request did not target the following hotfix branch(es) so they were left untouched: ...

## Test plan

- [ ] CI green
- [ ] `test_dev_pr_reminder_about_pre_ga_hotfix` still passes (branch name still appears in message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)