### PR TITLE
Fix robot-authored feature branch PRs being misrouted as integration PRs

### DIFF
--- a/bert_e/tests/unit/test_handle_pull_request.py
+++ b/bert_e/tests/unit/test_handle_pull_request.py
@@ -1,0 +1,61 @@
+"""Unit tests for gitwaterflow.handle_pull_request routing."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bert_e.workflow.gitwaterflow import handle_pull_request
+
+
+class _FakeRepo:
+    def __init__(self):
+        self._url = ''
+        self._remote_branches = {}
+
+    def cmd(self, *args, **kwargs):
+        return ''
+
+
+def _make_job(author, src_branch):
+    """Return a minimal PullRequestJob stub."""
+    pull_request = SimpleNamespace(
+        author=author,
+        src_branch=src_branch,
+        id=5171,
+    )
+    settings = SimpleNamespace(robot=author)
+    bert_e = SimpleNamespace(settings=settings)
+    git = SimpleNamespace(cascade=None, repo=_FakeRepo())
+    return SimpleNamespace(
+        pull_request=pull_request,
+        settings=settings,
+        bert_e=bert_e,
+        git=git,
+    )
+
+
+def test_robot_authored_integration_branch_routes_to_parent():
+    """A PR authored by the robot on a w/... branch must be routed to
+    handle_parent_pull_request — it's an integration PR."""
+    job = _make_job(author='bert-e',
+                    src_branch='w/4.2/improvement/ARTESCA-17563-something')
+
+    with patch('bert_e.workflow.gitwaterflow.handle_parent_pull_request') as mock_parent:
+        handle_pull_request(job)
+        mock_parent.assert_called_once_with(job, job.pull_request)
+
+
+def test_robot_authored_feature_branch_does_not_route_to_parent():
+    """A PR authored by the robot on a feature/... branch (e.g. a CID bump)
+    must NOT be routed to handle_parent_pull_request.
+
+    Regression: bert-e was crashing with 404 on bump PRs because it extracted
+    the first number in the description (a Jira ticket ID) and tried to fetch
+    a non-existent parent PR.
+    """
+    job = _make_job(author='bert-e',
+                    src_branch='feature/ARTESCA-17576-bump-identity-ui-0.41.0')
+
+    with patch('bert_e.workflow.gitwaterflow.handle_parent_pull_request') as mock_parent, \
+         patch('bert_e.workflow.gitwaterflow._handle_pull_request') as mock_handle:
+        handle_pull_request(job)
+        mock_parent.assert_not_called()
+        mock_handle.assert_called_once_with(job)

--- a/bert_e/tests/unit/test_handle_pull_request.py
+++ b/bert_e/tests/unit/test_handle_pull_request.py
@@ -10,9 +10,6 @@ class _FakeRepo:
         self._url = ''
         self._remote_branches = {}
 
-    def cmd(self, *args, **kwargs):
-        return ''
-
 
 def _make_job(author, src_branch):
     """Return a minimal PullRequestJob stub."""
@@ -33,25 +30,20 @@ def _make_job(author, src_branch):
 
 
 def test_robot_authored_integration_branch_routes_to_parent():
-    """A PR authored by the robot on a w/... branch must be routed to
-    handle_parent_pull_request — it's an integration PR."""
+    """Robot PR on w/... branch routes to handle_parent_pull_request."""
     job = _make_job(author='bert-e',
                     src_branch='w/4.2/improvement/ARTESCA-17563-something')
 
     parent_path = 'bert_e.workflow.gitwaterflow.handle_parent_pull_request'
-    with patch(parent_path) as mock_parent:
+    handle_path = 'bert_e.workflow.gitwaterflow._handle_pull_request'
+    with patch(parent_path) as mock_parent, patch(handle_path) as mock_handle:
         handle_pull_request(job)
         mock_parent.assert_called_once_with(job, job.pull_request)
+        mock_handle.assert_not_called()
 
 
 def test_robot_authored_feature_branch_does_not_route_to_parent():
-    """A PR authored by the robot on a feature/... branch (e.g. a CID bump)
-    must NOT be routed to handle_parent_pull_request.
-
-    Regression: bert-e was crashing with 404 on bump PRs because it extracted
-    the first number in the description (a Jira ticket ID) and tried to fetch
-    a non-existent parent PR.
-    """
+    """Robot PR on feature/... branch (CID bump) is not an integration PR."""
     job = _make_job(
         author='bert-e',
         src_branch='feature/ARTESCA-17576-bump-identity-ui-0.41.0',

--- a/bert_e/tests/unit/test_handle_pull_request.py
+++ b/bert_e/tests/unit/test_handle_pull_request.py
@@ -38,7 +38,8 @@ def test_robot_authored_integration_branch_routes_to_parent():
     job = _make_job(author='bert-e',
                     src_branch='w/4.2/improvement/ARTESCA-17563-something')
 
-    with patch('bert_e.workflow.gitwaterflow.handle_parent_pull_request') as mock_parent:
+    parent_path = 'bert_e.workflow.gitwaterflow.handle_parent_pull_request'
+    with patch(parent_path) as mock_parent:
         handle_pull_request(job)
         mock_parent.assert_called_once_with(job, job.pull_request)
 
@@ -51,11 +52,14 @@ def test_robot_authored_feature_branch_does_not_route_to_parent():
     the first number in the description (a Jira ticket ID) and tried to fetch
     a non-existent parent PR.
     """
-    job = _make_job(author='bert-e',
-                    src_branch='feature/ARTESCA-17576-bump-identity-ui-0.41.0')
+    job = _make_job(
+        author='bert-e',
+        src_branch='feature/ARTESCA-17576-bump-identity-ui-0.41.0',
+    )
 
-    with patch('bert_e.workflow.gitwaterflow.handle_parent_pull_request') as mock_parent, \
-         patch('bert_e.workflow.gitwaterflow._handle_pull_request') as mock_handle:
+    parent_path = 'bert_e.workflow.gitwaterflow.handle_parent_pull_request'
+    handle_path = 'bert_e.workflow.gitwaterflow._handle_pull_request'
+    with patch(parent_path) as mock_parent, patch(handle_path) as mock_handle:
         handle_pull_request(job)
         mock_parent.assert_not_called()
         mock_handle.assert_called_once_with(job)

--- a/bert_e/workflow/gitwaterflow/__init__.py
+++ b/bert_e/workflow/gitwaterflow/__init__.py
@@ -50,7 +50,8 @@ LOG = logging.getLogger(__name__)
 @handler(PullRequestJob)
 def handle_pull_request(job: PullRequestJob):
     """Analyse and handle a pull request that has just been updated."""
-    if job.pull_request.author == job.settings.robot:
+    if job.pull_request.author == job.settings.robot and re.match(
+            IntegrationBranch.pattern, job.pull_request.src_branch):
         return handle_parent_pull_request(job, job.pull_request)
     try:
         _handle_pull_request(job)


### PR DESCRIPTION
## Summary

- `handle_pull_request` was routing all robot-authored PRs to `handle_parent_pull_request` without checking whether the source branch was actually an `IntegrationBranch`
- CID bump PRs (e.g. `feature/ARTESCA-17576-bump-identity-ui-0.41.0`) are `FeatureBranch` instances created by the robot — bert-e was extracting the first number in the description (a Jira ticket ID from a URL) and trying to fetch a non-existent PR → 404
- Fix: also check that the source branch matches `IntegrationBranch.pattern` (`w/...`) before routing to `handle_parent_pull_request`

Closes PTFE-3261

## Test plan

- [x] `bert_e/tests/unit/test_handle_pull_request.py` — 2 new unit tests:
  - `test_robot_authored_integration_branch_routes_to_parent`: verifies that real integration PRs (`w/...`) are correctly routed
  - `test_robot_authored_feature_branch_does_not_route_to_parent`: regression test for the bug — a CID bump PR must not enter `handle_parent_pull_request`
- [ ] Verify on artesca that bert-e no longer crashes on CID bump PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)