### PR TITLE
fix: accept destination dev-branch ancestors in integration history check (PTFE-3343)

### DIFF
--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -1011,6 +1011,15 @@ class RepositoryTests(unittest.TestCase):
         )
         return pr
 
+    def branch_nondiverged_dev(self, base, new):
+        """Create development/<new> off development/<base> with no commit of
+        its own, so both development branches point at the exact same commit.
+
+        """
+        self.gitrepo.cmd('git checkout development/%s' % base)
+        self.gitrepo.cmd('git checkout -b development/%s' % new)
+        self.gitrepo.cmd('git push -u origin development/%s' % new)
+
     def handle_legacy(self, token, backtrace):
         """Allow the legacy tests (tests dating back before
         the queueing system) to continue working without modification.
@@ -3766,6 +3775,84 @@ always_create_integration_pull_requests: False
         self.gitrepo.cmd(
             'git push -u -f origin bugfix/TEST-00002:bugfix/TEST-00001')
         with self.assertRaises(exns.BranchHistoryMismatch):
+            self.handle(pr.id, options=self.bypass_all, backtrace=True)
+
+    def test_history_mismatch_nondiverged_dev_branch(self):
+        """A manually-resolved integration branch on a development branch that
+        has not diverged from its parent must not trigger a false
+        BranchHistoryMismatch.
+
+        development/4.4 is branched off development/4.3 with no commit of its
+        own, so both point at the exact same commit ``D``. A PR targeting
+        development/4.3 cascades into development/4.4. When the w/4.4
+        integration branch is manually resolved with a forced merge commit (as
+        an operator does when the higher development branch must ignore the
+        cascaded change, e.g. a `merge -s ours`), that merge commit's first
+        parent is ``D`` -- the commit shared with development/4.3. ``D`` is
+        part of the destination development branch and must be accepted.
+
+        """
+        # development/4.4 == development/4.3 (no commit of its own)
+        self.branch_nondiverged_dev('4.3', '4.4')
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        # First evaluation creates and pushes the integration branches.
+        with self.assertRaises(exns.BuildNotStarted):
+            self.handle(pr.id,
+                        options=self.bypass_all_but(['bypass_build_status']),
+                        backtrace=True)
+
+        # Manually resolve w/4.4 with a forced merge commit whose first parent
+        # is development/4.4's tip (== development/4.3's tip == D).
+        self.gitrepo.cmd('git fetch --all')
+        self.gitrepo.cmd('git checkout w/4.4/bugfix/TEST-00001')
+        self.gitrepo.cmd('git reset --hard development/4.4')
+        self.gitrepo.cmd('git merge --no-ff origin/bugfix/TEST-00001 '
+                         '-m "manual resolution of w/4.4"')
+        self.gitrepo.cmd('git push -f origin w/4.4/bugfix/TEST-00001')
+
+        # Re-evaluation runs the history check on the manual merge commit. It
+        # must not raise a false BranchHistoryMismatch.
+        with self.assertRaises(exns.SuccessMessage):
+            self.handle(pr.id, options=self.bypass_all, backtrace=True)
+
+    def test_history_mismatch_nondiverged_dev_auto_integration(self):
+        """When development/x.y+1 has not diverged from development/x.y (same
+        tip D) and the PR's feature branch was branched one commit before D,
+        bert-e auto-creates a w/x.y+1 integration branch via a real merge
+        commit (feature and D are siblings, not fast-forwardable). The merge
+        commit's first parent is D, which the git-log boundary excludes from
+        acceptable_parents. On re-evaluation the history check must accept D
+        as an ancestor of development/x.y+1 and not raise a false
+        BranchHistoryMismatch.
+
+        This exercises the same fix as
+        test_history_mismatch_nondiverged_dev_branch but via the auto-created
+        path rather than manual operator intervention.
+
+        """
+        # development/4.4 == development/4.3 (no commit of its own)
+        self.branch_nondiverged_dev('4.3', '4.4')
+
+        # Feature branch created one commit behind development/4.3's tip so
+        # that the merge for w/4.4 cannot fast-forward and produces a real
+        # merge commit whose first parent is development/4.4's tip (==
+        # development/4.3's tip).
+        parent_sha = self.gitrepo.cmd('git rev-parse development/4.3^').strip()
+        create_branch(self.gitrepo, 'bugfix/TEST-00001',
+                      from_branch=parent_sha, file_=True)
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3',
+                            reuse_branch=True)
+
+        # First evaluation creates and pushes the integration branches.
+        with self.assertRaises(exns.BuildNotStarted):
+            self.handle(pr.id,
+                        options=self.bypass_all_but(['bypass_build_status']),
+                        backtrace=True)
+
+        # Re-evaluation runs the history check on the auto-created merge
+        # commit. It must not raise a false BranchHistoryMismatch.
+        with self.assertRaises(exns.SuccessMessage):
             self.handle(pr.id, options=self.bypass_all, backtrace=True)
 
     def test_success_message_content(self):

--- a/bert_e/workflow/gitwaterflow/integration.py
+++ b/bert_e/workflow/gitwaterflow/integration.py
@@ -101,9 +101,18 @@ def update_integration_branches(job, wbranches):
         # * the wbranch,
         # * the previous integration branch,
         # * the target development branch.
+        #
+        # A `<dev>..<branch>` diff excludes the boundary commit, so when the
+        # destination development branch has not diverged from its parent (it
+        # points at the same commit), the shared tip is in none of the sets
+        # above even though it legitimately belongs to the target development
+        # branch. Accept any parent that is an ancestor of the destination
+        # development branch to cover that case.
         acceptable_parents = prev_set | dst_set | wbranch_set
         for rev in wbranch_set:
-            if not all(p in acceptable_parents for p in rev.parents):
+            if not all(p in acceptable_parents or
+                       wbranch.dst_branch.includes_commit(p)
+                       for p in rev.parents):
                 raise exceptions.BranchHistoryMismatch(
                     integration_branch=wbranch, feature_branch=feature_branch,
                     development_branch=wbranch.dst_branch, commit=rev,


### PR DESCRIPTION
## Problem

Bert-E raised a false `History mismatch` (`BranchHistoryMismatch`, code 113) — telling the user to `reset` even though nothing was rebased — when an integration branch sat on a development branch that had not diverged from its parent (`development/X.Y` freshly branched off `development/X.(Y-1)`, still pointing at the same commit `D`) and that integration branch carried a real merge commit.

## When it happens

The trigger is a real (non-fast-forward) merge commit on `w/X.Y` whose **first parent is the shared dev tip `D`**. Two ways to get there:

- **Automated cascade, "late" PR** — when the PR's feature branch was branched *before* `D` (the PR is behind the dev tip), the auto-created `w/X.Y` merge cannot fast-forward (feature and `D` are siblings), so Bert-E produces a real merge commit whose first parent is `D`. PRs are frequently behind the dev tip, so this is the common case. (Thanks @tcarmet for spotting this path.)
- **Manual resolution** — an operator hand-resolves `w/X.Y` with a forced merge commit (e.g. `git merge -s ours`) so the higher development branch ignores the cascaded change (the ARSN-600 scenario).

It does **not** trigger when the PR is already up-to-date with the dev tip: the merge then fast-forwards and no merge commit is created.

## Root cause

`update_integration_branches()` builds `acceptable_parents` from three `git log A..B` diffs (`prev_set`, `dst_set`, `wbranch_set`). `A..B` excludes the boundary commit, so when `development/X.Y == development/X.(Y-1)`, `dst_set` is empty and the shared dev tip `D` — the first parent of the integration merge — appears in none of the sets. The check then rejects a parent that legitimately belongs to the target development branch, contradicting the check's own documented intent (its comment explicitly allows parents from "the target development branch").

## Fix

Accept a merge parent that is an ancestor of the destination development branch (`Branch.includes_commit`, i.e. `git merge-base --is-ancestor`), matching the documented intent.

Genuine rebase / force-push detection is preserved: a rebased source leaves a merge whose offending parent is a feature-branch commit that is **not** an ancestor of any development branch, so it still raises. The existing `BranchHistoryMismatch` tests still pass. Two failing-first regression tests cover the non-diverged case:

- `test_history_mismatch_nondiverged_dev_branch` — manual-resolution path
- `test_history_mismatch_nondiverged_dev_auto_integration` — auto-created merge of a late PR

Full `tox -e tests-noqueue` and `tox -e tests` suites pass (202 tests each).

Jira: PTFE-3343
