### PR TITLE
docs: add OpenWiki documentation + nightly update workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "openwiki/**"
   push:
     branches:
       - main
+    paths-ignore:
+      - "openwiki/**"
 
 permissions: write-all
 

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -1,0 +1,112 @@
+name: OpenWiki Update
+
+on:
+  workflow_dispatch:
+  schedule:
+    # GitHub schedules use UTC; 02:00 UTC is nightly, off peak hours.
+    - cron: "0 2 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-for-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check for commits since the last OpenWiki update
+        id: check
+        run: |
+          last_head=$(jq -r '.gitHead // empty' openwiki/.last-update.json 2>/dev/null || true)
+          current_head=$(git rev-parse HEAD)
+
+          if [ -z "$last_head" ] || [ "$last_head" != "$current_head" ]; then
+            echo "Repository changed since last OpenWiki update ($last_head -> $current_head)."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No commits since last OpenWiki update ($current_head); skipping."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  update:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install OpenWiki
+        run: npm install --global openwiki
+
+      - name: Run OpenWiki
+        run: openwiki --update --print | tee "$RUNNER_TEMP/openwiki-run-summary.txt"
+        env:
+          OPENWIKI_PROVIDER: anthropic
+          OPENWIKI_MODEL_ID: claude-sonnet-5
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Push OpenWiki update and open pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- openwiki; then
+            echo "No OpenWiki changes to commit; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          summary_file="$RUNNER_TEMP/openwiki-run-summary.txt"
+          commit_message_file="$RUNNER_TEMP/openwiki-commit-message.txt"
+          pr_body_file="$RUNNER_TEMP/openwiki-pr-body.txt"
+
+          {
+            echo "docs: update OpenWiki"
+            echo
+            cat "$summary_file"
+          } > "$commit_message_file"
+
+          {
+            echo "Automated OpenWiki documentation update, opened by the nightly OpenWiki workflow after finding commits since the last recorded update. \`openwiki --update\` also runs its own no-op check internally, so this can still be a no-op if those commits didn't affect anything OpenWiki documents."
+            echo
+            echo "### What changed and why"
+            echo
+            echo "OpenWiki's own summary of this run:"
+            echo
+            cat "$summary_file"
+          } > "$pr_body_file"
+
+          git checkout -B openwiki/update
+          git add openwiki
+          git commit -F "$commit_message_file"
+          git push --force origin openwiki/update
+
+          open_pr_number=$(gh pr list --state open --head openwiki/update --json number --jq '.[0].number // empty')
+
+          if [ -z "$open_pr_number" ]; then
+            gh pr create \
+              --base main \
+              --head openwiki/update \
+              --title "docs: update OpenWiki" \
+              --body-file "$pr_body_file"
+          else
+            # gh pr edit hits a known GraphQL error on repos with legacy
+            # Projects (classic) enabled; go through the REST API instead.
+            jq -n --rawfile body "$pr_body_file" '{body: $body}' |
+              gh api "repos/${GITHUB_REPOSITORY}/pulls/${open_pr_number}" -X PATCH --input - > /dev/null
+            echo "PR #$open_pr_number already open on openwiki/update; pushed the update to it and refreshed its description."
+          fi

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -17,7 +17,7 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check for commits since the last OpenWiki update
         id: check
@@ -39,17 +39,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 
       - name: Install OpenWiki
-        run: npm install --global openwiki
+        # Pinned: unpinned install would run with contents:write and
+        # ANTHROPIC_API_KEY access, so a compromised future release could
+        # exfiltrate the key or push arbitrary code. Bump deliberately.
+        run: npm install --global openwiki@0.2.0
 
       - name: Run OpenWiki
         run: openwiki --update --print | tee "$RUNNER_TEMP/openwiki-run-summary.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,14 @@ gh release create <tag> --target "$FULL_SHA" --prerelease --generate-notes --tit
 ```
 
 Follow the checklist in `devdocs/docs/tools/bert-e/release.md` for the full release process (tag naming, pre-release flag, monitoring the Actions workflow, then updating devinfra).
+
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,6 @@
+{
+  "updatedAt": "2026-07-08T20:42:51.649Z",
+  "command": "init",
+  "gitHead": "6ddd9a58d2f0a746c8bdabb1e0caeb5c2fe8bd79",
+  "model": "claude-sonnet-5"
+}

--- a/openwiki/architecture/commands-and-options.md
+++ b/openwiki/architecture/commands-and-options.md
@@ -1,0 +1,100 @@
+# Commands and Options
+
+Users interact with Bert-E almost entirely through PR comments addressed to
+`@<robot>` (the robot's git host username). This page explains the generic
+mechanism (`bert_e/reactor.py`) and how it's wired to GitWaterFlow-specific
+behavior (`bert_e/workflow/gitwaterflow/commands.py`). For the end-user list
+of every option/command and their meaning, see the tables in
+[`bert_e/docs/USER_DOC.md`](../../bert_e/docs/USER_DOC.md) — this page
+covers the mechanism, not the full catalog.
+
+## Options vs. commands
+
+- **Options** are persistent: they stay active for as long as the comment
+  that set them remains on the PR (deleting the comment deactivates the
+  option). They're stored in `job.settings` and re-evaluated on every
+  Bert-E run. Example: `unanimity`, `bypass_build_status`.
+- **Commands** are one-shot: found once, executed once, not "remembered".
+  Example: `help`, `reset`, `force_reset`.
+
+Both are registered on a shared `Reactor` class (`bert_e/reactor.py`), which
+is a generic, dependency-light dispatcher (its only coupling to the rest of
+the app is that a "job" must expose a dict-like `.settings`). It is
+deliberately reusable/testable in isolation (see its module docstring for a
+runnable doctest-style example).
+
+## Registration API (`bert_e/reactor.py`)
+
+- `Reactor.command` — decorator (usable bare or with
+  `key=`, `help_=`, `privileged=True`) that registers a one-shot command.
+- `Reactor.option` / `Reactor.add_option` — decorator/function to register a
+  persistent option with a `default` value, optionally `privileged=True`
+  (admins only) or `authored=True` (PR author only).
+- `Reactor.init_settings(job)` — populates `job.settings` with every
+  registered option's default (deep-copied, so mutable defaults like `set()`
+  are safe to share across registrations).
+- `Reactor.handle_options` / `Reactor.handle_commands` — scan a comment's
+  text for `@robot <keyword>[=value]` tokens and invoke the matching
+  handler, raising `NotFound` / `NotPrivileged` / `NotAuthored` for the
+  caller to translate into a user-facing message.
+
+## Wiring in GitWaterFlow (`bert_e/workflow/gitwaterflow/commands.py` and `.../utils.py`)
+
+`commands.py::setup(defaults={})` is called once at startup (from
+`gitwaterflow/__init__.py`, imported as `from .commands import setup  #
+noqa`) and registers every GitWaterFlow-specific option (all the
+`bypass_*` options, `unanimity`, `wait`, `after_pull_request`,
+`create_pull_requests`, `create_integration_branches`, `approve`,
+`no_octopus`, ...) and command (`help`, `status`, `reset`, `force_reset`,
+plus stubs `build`/`retry`/`clear` that raise `CommandNotImplemented`).
+`defaults` lets a repository's `settings.yml` override an option's default
+(see `settings.sample.yml`).
+
+`bert_e/workflow/gitwaterflow/utils.py` holds small predicates like
+`bypass_incompatible_branch(job)` that just read the corresponding
+`job.settings.bypass_*` flag — these are what the pipeline checks in
+`__init__.py` call to decide whether to skip a validation.
+
+`handle_comments()` in `gitwaterflow/__init__.py` is where the reactor is
+actually driven for a given PR:
+
+1. It walks **all** comments (in original order) through
+   `reactor.handle_options`, computing `privileged` (comment author is in
+   `settings.admins`) and `authored` (comment author is the PR author) per
+   comment, and turns `NotFound`/`NotPrivileged`/`NotAuthored` into the
+   corresponding `bert_e.exceptions` messages (`UnknownCommand`,
+   `NotEnoughCredentials`, `NotAuthor`).
+2. It then walks comments **in reverse** through `reactor.handle_commands`,
+   stopping as soon as it reaches a comment authored by the robot itself
+   (so commands are only executed from comments posted *after* Bert-E's
+   last reply).
+
+## How to add a new command or option
+
+1. Pick a unique keyword. Decide: persistent behavior (`Reactor.option`,
+   needs a default) or one-shot action (`Reactor.command`).
+2. Register it in `commands.py::setup()` (or add a new
+   `@Reactor.command`/`@Reactor.option`-decorated function near the existing
+   ones) — set `privileged=True` if only admins should use it.
+3. If it should have a specific side effect beyond "set a settings flag",
+   write a dedicated handler function (see `after_pull_request` for an
+   option, `force_reset`/`reset` for commands) instead of relying on the
+   generic `add_option` setter.
+4. If the option gates a check in the pipeline, read it via
+   `job.settings.<key>` inside `bert_e/workflow/gitwaterflow/__init__.py`
+   (see the existing `bypass_*` usages).
+5. Add/adjust the entry in the option/command tables in
+   `bert_e/docs/USER_DOC.md`.
+6. Add unit tests (`bert_e/tests/unit/`) and, for behavior affecting the
+   merge pipeline, functional coverage in `bert_e/tests/test_bert_e.py`.
+
+## What to watch out for
+
+- Command/option keywords are matched against **all** comment text with the
+  `@<robot>` prefix — pick keywords that won't collide with normal English
+  words users might type after mentioning the robot.
+- `privileged`/`authored` checks happen at the `Reactor` level based on
+  `job.settings.admins` and the PR author — don't re-implement privilege
+  checks ad hoc inside a handler.
+- Options are evaluated fresh on every run from the current comment list;
+  there is no persisted state beyond "is the setting comment still present".

--- a/openwiki/architecture/gitwaterflow.md
+++ b/openwiki/architecture/gitwaterflow.md
@@ -1,0 +1,163 @@
+# GitWaterFlow Engine
+
+This is the core business logic of Bert-E: the branching model, the checks a
+pull request must pass, and the merge queue that lands code on
+`development/*` branches. Read this before changing any merge/branching
+behavior. For how a webhook/job reaches this code, see
+[overview.md](overview.md).
+
+The authoritative, user-facing description of these rules (message-code
+table, full option/command list, worked queue scenarios) lives in
+[`bert_e/docs/USER_DOC.md`](../../bert_e/docs/USER_DOC.md) — **update it
+whenever observable behavior changes**. This page explains the implementation
+and the "why", and links into that table rather than duplicating it.
+
+## Branch taxonomy (`bert_e/workflow/gitwaterflow/branches.py`)
+
+Every branch name is parsed into a typed object by `branch_factory()`, which
+tries each `GWFBranch` subclass's regex `pattern` in turn:
+
+| Class | Pattern example | Role |
+|---|---|---|
+| `FeatureBranch` | `feature/KEY-123-x`, `bugfix/...`, `improvement/...` | Source branches carrying a change; `cascade_producer = True` |
+| `DevelopmentBranch` | `development/6`, `development/6.0` | Destination branches; both a cascade producer and consumer |
+| `HotfixBranch` | `hotfix/6.0.1` | Destination for hotfixes on a released version; `can_be_destination = True` |
+| `LegacyHotfixBranch` | `hotfix/<label>` | Older, unversioned hotfix naming, kept for compatibility |
+| `ReleaseBranch` | `release/6.0` | Marks a version as released |
+| `UserBranch` | `user/...` | Explicitly ignored by Bert-E |
+| `IntegrationBranch` / `GhostIntegrationBranch` | `w/6.0/feature/KEY-123-x` | Temporary branch merging a feature branch's latest code onto one destination branch; one per (PR, destination) pair |
+| `QueueBranch` / `QueueIntegrationBranch` | `q/6.0`, `q/<pr>/6.0/...` | Merge-queue branches (see below) |
+
+Key invariants encoded here:
+- **Cascade**: a change accepted into one `development/x` branch must also
+  reach every later `development/*` branch. `BranchCascade` (bottom of
+  `branches.py`) builds the ordered set of destination branches from the
+  existing `development/*`, `hotfix/*`, and `release/*` branches and computes
+  merge paths (`get_merge_paths`, `_set_target_versions`, `finalize`).
+- **Version ordering**: `compare_branches`/`_compare_version_component`
+  implement the specific ordering rule `4.3 < 4 < 5.1 < 10.0 < 10` (minor
+  branches sort before their major-only counterpart) — this is
+  repository-specific and easy to get subtly wrong; there are dedicated unit
+  tests for it (`bert_e/tests/unit/test_queueing.py` and others).
+  Pre-GA hotfixes (`hfrev`) and "phantom" hotfix versions are a newer, more
+  delicate area — see `HotfixBranch.hfrev`, `pending_hotfix_branches`,
+  `phantom_hotfix_versions`, and `update_versions()` in `branches.py`, and
+  recent git history on `branches.py`/`jira.py` for the pre-GA hotfix
+  reminder feature.
+
+## The pull request pipeline (`bert_e/workflow/gitwaterflow/__init__.py`)
+
+`handle_pull_request` → `_handle_pull_request` runs a strict, ordered
+sequence of checks. Each check either passes silently or raises a
+`bert_e.exceptions.TemplateException` subclass (see "Exceptions are the
+control flow" below), which becomes a PR comment and stops processing for
+that run. In order:
+
+1. `early_checks` — is the PR open, destination a `development/*` branch,
+   source branch usable at all.
+2. `send_greetings` — first-time welcome comment (`InitMessage`).
+3. `handle_comments` — parses all PR comments through the `Reactor`
+   (see [commands-and-options.md](commands-and-options.md)) to compute
+   `job.active_options` and execute any one-shot commands.
+4. `check_dependencies` — `after_pull_request` option: wait for other PRs.
+5. `clone_git_repo` — from here on the code operates on a real local clone.
+6. `check_branch_compatibility` — source-branch prefix valid for destination
+   (`bypass_incompatible_branch`).
+7. `jira_checks` (`jira.py`) — ticket reference, project, issue type vs
+   branch prefix, Fix Version coherence (`bypass_jira_check`); includes the
+   pre-GA hotfix "pending fix version" one-time reminder.
+8. `check_commit_diff` — diff size limit (`max_commit_diff` setting).
+9. `create_integration_branches` / `create_integration_pull_requests`
+   (`integration.py`) — build the `w/<version>/<branch>` branches (and
+   optionally PRs) for every destination in the cascade;
+   `check_integration_branches` detects manual tampering and offers
+   `reset`/`force_reset`.
+10. `check_in_sync` / `check_pull_request_skew` — integration branches still
+    match the current PR head and destination.
+11. `check_approvals` — author approval (not on GitHub) and peer/leader
+    approval counts, with `unanimity`, `bypass_*_approval` options.
+12. `check_build_status` / `revalidate_build_status` — build status on
+    integration branches must be green; the latter does a **live** re-check
+    right before merging to avoid racing a stale cached status
+    (`bypass_build_status`).
+13. `merge_integration_branches` — the actual merge. If `use_queue` is
+    enabled (default), this **adds PRs to the merge queue** instead of
+    merging directly to `development/*` (see below); otherwise it merges
+    each integration branch straight onto its destination.
+
+`handle_commit` reacts to build-status webhooks: it maps the updated commit
+back to its branch(es); if any are queue branches it re-runs the queue
+handler (`queueing.handle_merge_queues`), otherwise it re-runs
+`handle_pull_request` for the owning PR so the pipeline above re-evaluates
+build status.
+
+### Exceptions are the control flow
+
+`bert_e/exceptions.py` defines one exception class per outcome/message,
+each with a numeric `code`, a Markdown `template` (rendered from
+`bert_e/templates/`), and a `dont_repeat_if_in_history` policy controlling
+whether Bert-E re-posts the same comment on every run. This is the
+mechanism used to talk to PR authors — **there is no separate "notification"
+system**; raising the right exception *is* how you send a message or stop
+processing. When adding a new check, add a matching exception + template
+pair here, and reference the message-code table in `USER_DOC.md`.
+
+## The merge queue (`bert_e/workflow/gitwaterflow/queueing.py`)
+
+When `use_queue` is enabled (the default, toggled by `disable_queues`
+setting), a validated PR is not merged immediately. Instead:
+
+- `add_to_queue` creates `q/<pr_id>/<version>/...` (`QueueIntegrationBranch`)
+  branches stacked on top of the current `q/<version>` (`QueueBranch`) tip,
+  for every destination version, and pushes a combined build.
+- `QueueCollection` (in `branches.py`) reconstructs the full picture of all
+  queued branches across all versions from the repository's branch list
+  (`build_queue_collection`), and `validate()` performs horizontal
+  (per-version) and vertical (cross-version, cascade-consistency) validation
+  to compute which queued PRs have an all-green, fully-stacked build
+  (`mergeable_queues` / `mergeable_prs`) versus which failed
+  (`failed_prs`).
+- `handle_merge_queues` (registered for `QueuesJob`, triggered by a build
+  status change on a queue branch, or the `rebuild_queues`/`force_merge_queues`
+  maintenance jobs) is the periodic reconciliation: build the cascade,
+  build the queue collection, validate it, and if there is a mergeable
+  prefix of the queue, fast-forward the real `development/*`/`hotfix/*`
+  branches (`merge_queues`), close out the corresponding PRs
+  (`close_queued_pull_request`), and push everything with `--prune`.
+
+This "optimistic queueing" design lets multiple PRs build concurrently
+against a stacked, speculative history, and only promotes commits once the
+whole stack from the front of the queue is green — see the worked scenarios
+in `USER_DOC.md` for the user-visible behavior.
+
+## Jira integration (`bert_e/workflow/gitwaterflow/jira.py`)
+
+When `jira_account_url`/`jira_keys` are configured, `jira_checks` validates
+the ticket referenced in the branch name: existence, project membership,
+issue type vs. the `prefixes` mapping in settings, and Fix Version
+consistency with the cascade of destination branches. `bert_e/lib/jira.py`
+is the thin REST client. Pre-GA hotfix branches get special handling
+(`_notify_pending_hotfix_if_needed`) to remind authors once about a required
+follow-up cherry-pick, without repeating on every run.
+
+## What to watch out for
+
+- **Order matters.** The pipeline stops at the first failing check; moving a
+  check earlier/later changes which message a user sees first. Match new
+  checks to the existing order described in `USER_DOC.md`.
+- **`GWFBranch.__eq__`/`__lt__` and `version_t`** encode subtle,
+  repository-specific version-ordering rules (major vs `major.minor`,
+  hotfix `hfrev`, pre-GA "phantom" versions). Changes here have historically
+  caused regressions (see git history on `branches.py` and
+  `bert_e/tests/unit/test_queueing.py`) — always add/adjust unit tests
+  alongside any change.
+- **Exceptions carry `dont_repeat_if_in_history`.** Get this wrong and users
+  either get spammed on every run or never see an important message again.
+- **Robot-authored PRs** (integration PRs, whose source branch matches
+  `IntegrationBranch.pattern`) are routed to `handle_parent_pull_request`
+  instead of being treated as a normal feature PR — don't break this
+  dispatch when touching `handle_pull_request`.
+- Most of this logic is exercised by the large functional suite
+  `bert_e/tests/test_bert_e.py` run against the `mock` git host (tox env
+  `tests`), plus focused unit tests in `bert_e/tests/unit/`. See
+  [operations/running-and-testing.md](../operations/running-and-testing.md).

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -1,0 +1,173 @@
+# Architecture Overview
+
+This page explains how Bert-E is wired together end to end: from an
+incoming webhook or API call, to a queued job, to actual git operations
+against the target repository. For the merge/branching business logic
+itself, see [gitwaterflow.md](gitwaterflow.md).
+
+## High-level flow
+
+```
+GitHub/Bitbucket webhook  ──┐
+REST API call             ──┼──▶  Job (PullRequestJob / CommitJob / QueuesJob / APIJob subclass)
+CLI invocation (bert-e)   ──┘             │
+                                           ▼
+                              BertE.put_job()  (dedups equal jobs)
+                                           │
+                                           ▼
+                         background worker thread: BertE.process_task()
+                                           │
+                                           ▼
+                    JobDispatcher.dispatch(job)  (bert_e/lib/dispatcher.py,
+                    MRO-aware: matches job's class or a superclass to a
+                    @handler-registered function)
+                                           │
+                                           ▼
+                gitwaterflow handler (handle_pull_request / handle_commit /
+                handle_merge_queues) — see gitwaterflow.md
+                                           │
+                                           ▼
+        git_host client (GitHub/Bitbucket/mock) + local git clone (bert_e/lib/git.py)
+```
+
+Source: `bert_e/bert_e.py` (`BertE` class, `process_task`, `put_job`),
+`bert_e/job.py`, `bert_e/lib/dispatcher.py`.
+
+## The `BertE` core object (`bert_e/bert_e.py`)
+
+`BertE` is constructed once per running process from a loaded `settings`
+object. On construction it:
+
+- builds a git-host client via `client_factory(settings.repository_host, ...)`
+  (GitHub, Bitbucket, or `mock` for tests) — see "Git host abstraction" below;
+- resolves `project_repo` (the target repo on the host);
+- clones the repository locally into a temp directory (`GitRepository` from
+  `bert_e/lib/git.py`), which is where all merges/conflicts actually happen;
+- holds an in-process `Queue` of pending jobs (`task_queue`) and a bounded
+  history of completed jobs (`tasks_done`, capped at 1000) used by the
+  status page and `/api/jobs`.
+
+`process_task()` is run in a loop by a background thread (started in
+`bert_e/server/__init__.py::setup_bert_e`). It pops one job, calls
+`self.process(job)` (which resets/dispatches), and records success/failure.
+Errors that are not `BertE_Exception`/`InternalException` are logged as
+unexpected; `JobFailure` is logged as an expected API failure. This is the
+central place to look when debugging "why didn't my job run" or "why did
+processing crash".
+
+## Jobs (`bert_e/job.py`, `bert_e/jobs/`)
+
+A **Job** is the unit of work carried on the task queue. Base classes:
+
+- `Job` — id (uuid4), layered `settings` (per-job overrides merged over the
+  global repository settings via `SettingsDict`), timing, status/details,
+  JSON serialization for the API/status page.
+- `RepoJob` — adds `project_repo` and a `git` namespace holding the local
+  repo handle and the shared `BranchCascade` for this run.
+- `PullRequestJob` — triggered by PR webhook events (open/update/comment/
+  review); carries the `pull_request` object and per-author bypass options
+  (from `pr_author_options` in settings).
+- `CommitJob` — triggered by commit/build-status webhook events; used to
+  react to build results on integration/queue branches.
+- `QueuesJob` — merge-queue maintenance (supports `force_merge`).
+- `APIJob` — base class for jobs triggered through the REST API; concrete
+  subclasses live in `bert_e/jobs/*.py` (see
+  [operations/running-and-testing.md](../operations/running-and-testing.md)).
+
+Handlers are registered with the `@handler(JobClass)` decorator and
+dispatched via `JobDispatcher`/`Dispatcher` (`bert_e/lib/dispatcher.py`),
+which walks the job's MRO so a handler registered for a base class also
+matches subclasses.
+
+## Settings (`bert_e/settings.py`, `settings.sample.yml`)
+
+Settings are loaded from a YAML file and validated with a `marshmallow`
+schema (`setup_settings`). They define per-repository configuration:
+git host, robot credentials, Jira integration, approval requirements,
+branch-prefix rules, bypass privileges (`admins`, `pr_author_options`),
+and queue-related toggles (`always_create_integration_branches`,
+`always_create_integration_pull_requests`, `disable_queues`,
+`max_commit_diff`). `settings.sample.yml` is the authoritative, commented
+reference for every option — read it before adding a new setting.
+
+Per-job settings (`Job.settings`) are a `SettingsDict` layering
+request-specific overrides (e.g. an author's personal bypass options) on
+top of the global settings, so handler code can read `job.settings.xxx`
+without caring where the value came from.
+
+## Git host abstraction (`bert_e/git_host/`)
+
+Bert-E supports GitHub and Bitbucket (plus an in-memory `mock` used
+throughout the test suite) behind one abstract interface:
+
+- `base.py` defines `AbstractClient`, `AbstractRepository`,
+  `AbstractPullRequest`, `AbstractComment`, `AbstractBuildStatus` — the
+  contract every provider must implement (fetch/approve/decline/comment on
+  PRs, read/set build status, create/delete repos, etc.), plus
+  `BertESession`, a `requests.Session` with retry/backoff on flaky
+  responses (raises `FlakyGitHost` after exhausting retries).
+- `factory.py` is a small registry: each provider module registers itself
+  with `@factory.api_client('github')` / `'bitbucket'`, and
+  `client_factory(service, ...)` looks up the right class by the
+  `repository_host` setting.
+- `github/__init__.py` and `bitbucket/__init__.py` are the concrete
+  implementations (each with its own `schema.py` for marshmallow
+  (de)serialization of the provider's REST payloads).
+- `mock.py` is a fully in-memory fake client, used by the functional test
+  suite (`bert_e/tests/test_bert_e.py --git-host mock`) so that GitWaterFlow
+  logic can be exercised without hitting a real git host.
+- `cache.py` holds `BUILD_STATUS_CACHE`, used by the webhook handlers and
+  status page to avoid redundant build-status lookups.
+
+When adding support for a new check or PR attribute, extend the abstract
+base first, then implement it in both `github/` and `bitbucket/`
+(and `mock.py`, so tests can cover it).
+
+## The Flask server (`bert_e/server/`)
+
+`bert_e/server/__init__.py` wires everything into a Flask app:
+
+- `setup_bert_e()` constructs the `BertE` instance and starts the
+  background worker thread described above.
+- `setup_server()` builds the Flask app, configures webhook/OAuth
+  credentials and CSRF key, and registers blueprints for the API, webhook
+  receivers, status page, management UI, docs, auth, and session handling.
+
+Key modules:
+- `webhook.py` — receives `/bitbucket` and `/github` webhooks (behind HTTP
+  basic auth), parses event type, and turns supported events (PR
+  opened/updated, issue/PR comments, PR reviews, commit/check-suite status)
+  into `PullRequestJob`/`CommitJob` instances submitted via `bert_e.put_job`.
+- `status.py` — renders the live status page: current job, queued jobs,
+  recently merged PRs, and per-version merge-queue state.
+- `auth.py` / `session.py` — OAuth login (GitHub/Bitbucket) plus basic auth
+  for webhook endpoints; see
+  [operations/api-and-integrations.md](../operations/api-and-integrations.md).
+- `api/` — REST endpoints that map directly onto `bert_e/jobs/*.py` job
+  classes (see the same operations page and `bert_e/docs/API_DOC.md`).
+
+## Supporting libraries (`bert_e/lib/`)
+
+- `git.py` — thin wrapper around the `git` CLI (`simplecmd.py` runs shell
+  commands) used for cloning, branching, merging, and inspecting history.
+- `dispatcher.py` — the generic MRO-aware handler registry used by jobs.
+- `retry.py` — a retry decorator used around flaky network operations.
+- `template_loader.py` — loads and renders the Markdown templates in
+  `bert_e/templates/` (used by `TemplateException`, see
+  [gitwaterflow.md](gitwaterflow.md#exceptions-are-the-control-flow)).
+- `settings_dict.py` — the layered-dict type used for settings and job
+  options.
+- `schema.py`, `versions.py`, `jira.py`, `lru_cache.py` — marshmallow
+  schema helpers, semantic-version parsing, a small Jira REST client, and
+  an LRU cache utility.
+
+## What to watch out for
+
+- The local git clone in `self.tmpdir` is shared/reset per job
+  (`BertE.process`); handlers assume a clean, correctly-checked-out repo at
+  the start of each run.
+- Job deduplication (`put_job`) relies on `Job.__eq__`; if you add a new Job
+  subclass, make sure duplicate-submission semantics are what you expect.
+- Any new git-host capability must be added to `base.py` and implemented
+  consistently in `github/`, `bitbucket/`, and `mock.py`, or the mock-backed
+  functional tests will not exercise it.

--- a/openwiki/operations/api-and-integrations.md
+++ b/openwiki/operations/api-and-integrations.md
@@ -1,0 +1,102 @@
+# API and Integrations
+
+## REST API (`bert_e/server/api/`)
+
+Full endpoint reference (auth flow, request/response bodies, examples) is
+authoritative in [`bert_e/docs/API_DOC.md`](../../bert_e/docs/API_DOC.md) —
+this page summarizes the mechanism and where to extend it.
+
+- `server/api/__init__.py` registers the API blueprint and its
+  sub-resources.
+- `server/api/base.py` — shared helpers: turning a `Job` into a JSON
+  response, permission checks (session user vs. `admins`/repo membership).
+- `server/api/jobs.py` — `GET /api/jobs` (list, capped at the last 1000
+  completed + in-flight) and `GET /api/jobs/<id>` (single job status). Maps
+  directly onto `BertE.tasks_done` / `task_queue` described in
+  [architecture/overview.md](../architecture/overview.md).
+- `server/api/pull_requests.py` — `POST /api/pull-requests/<id>` creates an
+  `eval_pull_request`-style job to (re-)evaluate a PR outside of a webhook.
+- `server/api/gwf/` — endpoints that map onto the maintenance `Job`
+  subclasses in `bert_e/jobs/` (create/delete branch, rebuild/force-merge/
+  delete queues) — see
+  [running-and-testing.md](running-and-testing.md#maintenance-jobs-bert_ejobs).
+
+Adding a new API endpoint typically means: define a new `APIJob` subclass in
+`bert_e/jobs/`, register a `@handler(...)` function for it (see
+[architecture/overview.md](../architecture/overview.md#jobs-bert_ejobpy-bert_ejobs)),
+then expose it via a new route in `server/api/`.
+
+## Authentication (`bert_e/server/auth.py`, `session.py`)
+
+Two distinct auth mechanisms, for two distinct audiences:
+
+- **Webhook endpoints** (`/github`, `/bitbucket` in `server/webhook.py`) are
+  protected by HTTP Basic Auth (`requires_basic_auth` decorator), using
+  credentials configured on the git host side when the webhook was
+  registered (see `bin/webhook_register.py`).
+- **Human-facing API/UI** uses OAuth login against GitHub or Bitbucket via
+  `authlib`/`loginpass` (`server/auth.py`), establishing a Flask session
+  (`server/session.py`) after `/api/auth` validates the provider access
+  token. Session-authenticated users are authorized against the
+  repository's `admins` setting for privileged operations.
+
+Never commit real client secrets/tokens; they are supplied as environment
+variables at deploy time (see `[testenv:run]` in `tox.ini` and
+`charts/bert-e/values.yaml` for how secrets are wired in each environment).
+
+## Webhooks (`bert_e/server/webhook.py`)
+
+Single entry point that turns git-host webhook payloads into `Job`s pushed
+onto `BertE`'s queue (`bert_e.put_job`, see
+[architecture/overview.md](../architecture/overview.md)):
+
+- **Bitbucket**: `handle_bitbucket_repo_event` (commit/build status changes
+  → `CommitJob`) and `handle_bitbucket_pr_event` (PR created/updated/
+  commented/reviewed → `PullRequestJob`).
+- **GitHub**: `handle_github_pr_event` (PR events, ignoring `closed`),
+  `handle_github_issue_comment` (issue/PR comments), and check-suite/status
+  events → `CommitJob`. GitHub events are parsed into typed objects (e.g.
+  `github.PullRequestEvent`) via each provider's `schema.py`.
+
+Build-status events are cached in `BUILD_STATUS_CACHE`
+(`bert_e/git_host/cache.py`) to avoid redundant lookups when many statuses
+arrive in a burst (e.g. CI reporting several checks).
+
+## Git host abstraction
+
+See [architecture/overview.md](../architecture/overview.md#git-host-abstraction-bert_egit_host)
+for the `base.py`/`factory.py`/`mock.py`/`github/`/`bitbucket/` breakdown.
+Practical integration notes:
+
+- New provider capabilities must be added to `base.AbstractClient` (or the
+  relevant `Abstract*` class) first, then implemented in **both**
+  `github/__init__.py` and `bitbucket/__init__.py`, and in `mock.py` so the
+  functional test suite exercises it (`tox -e tests`).
+  `bert_e/tests/test_git_host.py` (run via `tox -e tests-api-mock`) is the
+  contract test suite for the abstraction itself.
+- Each provider has its own `schema.py` for marshmallow (de)serialization of
+  that provider's REST payloads — this is where field-name differences
+  between GitHub and Bitbucket are absorbed.
+
+## Jira integration
+
+Configured per-repository via `jira_account_url`, `jira_email`, `jira_keys`,
+and `prefixes` in `settings.yml` (see `settings.sample.yml` for the full,
+commented list). If `jira_account_url`/`jira_email`/`jira_keys` are empty,
+Jira checks are skipped entirely.
+
+- `bert_e/lib/jira.py` — thin wrapper (`JiraIssue`) around the `jira` Python
+  client, doing basic-auth (email + API token) lookups of a single issue.
+- `bert_e/workflow/gitwaterflow/jira.py` — the actual business checks run
+  against a PR's branch (issue exists, project matches `jira_keys`, issue
+  type matches the branch prefix via `prefixes`, Fix Version/s field is
+  coherent with the target branch, including pre-GA hotfix nuances). See
+  [architecture/gitwaterflow.md](../architecture/gitwaterflow.md#jira-integration)
+  for the business rules and message codes.
+
+## Existing docs to read alongside this page
+
+- [`bert_e/docs/API_DOC.md`](../../bert_e/docs/API_DOC.md) — full endpoint
+  reference with request/response examples.
+- [`bert_e/docs/USER_DOC.md`](../../bert_e/docs/USER_DOC.md) — end-user
+  facing behavior (options, commands, message codes).

--- a/openwiki/operations/running-and-testing.md
+++ b/openwiki/operations/running-and-testing.md
@@ -1,0 +1,117 @@
+# Running, Testing, and Deploying
+
+## Local development
+
+Bert-E's only supported dev method is the provided codespace/devcontainer
+(`.devcontainer/`). From inside it:
+
+```shell
+cp settings.sample.yml settings.yml   # edit to your liking, see settings.sample.yml
+tox run -e run                        # runs bert-e-serve on :8000 (tox.ini [testenv:run])
+```
+
+`[testenv:run]` (`tox.ini`) sets `BERT_E_CLIENT_ID`/`BERT_E_CLIENT_SECRET`/
+`BERT_E_ROBOT_PASSWORD`/`BERT_E_JIRA_TOKEN`/`WEBHOOK_LOGIN`/`WEBHOOK_PWD` from
+environment (falling back to dev defaults), then runs
+`bert-e-serve -v -f settings.yml -p 8000` (entry point defined in
+`setup.py`, implemented in `bert_e/server/server.py`).
+
+Per `CLAUDE.md`, `pytest` is installed at `.venv/bin/pytest` (not on PATH) —
+use that directly, or the tox environments below, which is the primary
+supported way to run tests.
+
+## Test environments (`tox.ini`)
+
+| tox env | What it runs | Notes |
+|---|---|---|
+| `flake8` | `flake8 bert_e/` | Style/lint gate |
+| `utests` | `pytest bert_e/tests/unit/` | Fast, isolated unit tests |
+| `tests-api-mock` | `pytest -k mock bert_e/tests/test_git_host.py` | Git-host client contract tests against the mock |
+| `tests-server` | `pytest bert_e/tests/test_server.py` | Flask server/API/webhook tests |
+| `tests-noqueue` | `bert_e.tests.test_bert_e` with `--git-host mock --disable-queues` | Full functional suite, queue feature off |
+| `tests` | `bert_e.tests.test_bert_e` with `--git-host mock` | Full functional suite, queues on — the main GitWaterFlow regression suite |
+| `tests-githost` | Same functional suite against a **real** configured git host | Needs real credentials, see below |
+| `coverage-report` | `coverage report` / `coverage html` | |
+
+`bert_e/tests/test_bert_e.py` is organized into test *classes* matching real
+scenarios (visible in the CI matrix): `QuickTest`, `BuildFailedTest`,
+`RepositoryTests`, `TestBertE`, `TestQueueing`, `TaskQueueTests`. Pass a
+class name as a positional arg (`{posargs}`) to run just that subset — this
+is how `.github/workflows/main.yaml` parallelizes the functional suite.
+
+Running against a real git host (`tests-githost`) requires credentials for a
+team/org, a robot account, a contributor account, and an admin account —
+see the env vars listed in `tox.ini`'s `[testenv:tests-githost]` and don't
+put real credentials in `settings.yml`/tracked files.
+
+## CI (`.github/workflows/`)
+
+- `main.yaml` ("basic tests") — on every PR/push to `main`: matrix of
+  `unit` (`utests`, `tests-api-mock`, `tests-server`), `integration`
+  (`tests-noqueue` × `tests`, each × the 6 test classes above), and `lint`
+  (`flake8` + `helm lint charts/bert-e`). Coverage uploaded to Codecov
+  (`codecov.yml`).
+- `build.yaml` — builds/pushes the Docker image.
+- `release.yaml` — manual workflow_dispatch release process, see
+  `RELEASE.md` (tags a commit, builds+pushes the image, creates a GitHub
+  Release). `CLAUDE.md` documents the practical gotcha: `gh release
+  create --target` needs the **full** commit SHA, not a short one.
+- `codeql.yml`, `trivy.yaml` — security scanning.
+
+## Maintenance jobs (`bert_e/jobs/`)
+
+These are `APIJob` subclasses, triggered via the REST API (see
+[api-and-integrations.md](api-and-integrations.md)) rather than by webhooks,
+for operations an admin needs to trigger by hand:
+
+- `create_branch.py` — create a new `development/*`/`hotfix/*` destination
+  branch and fold it into the cascade.
+- `delete_branch.py` — remove a destination branch.
+- `rebuild_queues.py` — recompute/repair the merge queue from scratch.
+- `force_merge_queues.py` — force-merge the current queue state.
+- `delete_queues.py` — drop all queue (`q/*`) branches.
+- `eval_pull_request.py` — force (re-)evaluation of a specific PR outside
+  the normal webhook trigger.
+
+Each defines a `Job` subclass plus a `@handler(...)`-registered function
+following the same dispatcher pattern described in
+[architecture/overview.md](../architecture/overview.md).
+
+## Standalone CLI scripts (`bert_e/bin/`)
+
+Installed as console scripts by `setup.py`, independent of the running
+server:
+
+- `webhook_register.py` (`webhook_register`) — registers the Bitbucket
+  webhook events Bert-E needs on a repository.
+- `webhook_parser.py` (`webhook_parser`) — decodes/inspects a raw webhook
+  payload for debugging.
+- `filter_pull_requests.py` (`filter_pull_requests`) — lists/filters PRs
+  matching criteria.
+- `nobuildstatus.py` (`nobuildstatus`) — finds commits/branches missing a
+  build status.
+
+## Deployment
+
+- **Docker** (`Dockerfile`): `python:3.10-slim-bullseye` base, installs
+  `git` + `requirements.txt`, installs the package, entrypoint
+  `bert-e-serve`. Built/pushed by `build.yaml`/`release.yaml`.
+- **Kubernetes**: `charts/bert-e/` is the Helm chart (values in
+  `values.yaml`, linted in CI via `helm lint`); `manifests/` holds Kustomize
+  manifests for environment-specific overlays. Treat `values.yaml`/manifests
+  as the reference for what's configurable at deploy time (replica count,
+  ingress, secrets wiring) rather than duplicating it here.
+- Runtime configuration is a per-repository `settings.yml` validated by
+  `bert_e/settings.py`; **never commit real secrets** — robot passwords,
+  OAuth secrets, and Jira tokens are supplied via environment/secret store,
+  not the settings file itself (see the `[MANDATORY]`/`[OPTIONAL]` comments
+  in `settings.sample.yml` for the full list of fields and what's sensitive).
+
+## What to watch out for
+
+- The `tests`/`tests-noqueue` functional suite is the primary safety net for
+  GitWaterFlow business-logic changes; always run the relevant test
+  class(es) locally before considering a merge/queue change done.
+- `flake8` (E501 line length, etc.) is enforced in CI; several past commits
+  exist solely to fix lint violations — run `tox -e flake8` before pushing.
+- `helm lint charts/bert-e` is also a CI gate if you touch the chart.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,69 @@
+# Bert-E — OpenWiki Quickstart
+
+## What is this repository?
+
+**Bert-E** is Scality's automated Git branch-merging bot. It is the *only*
+account allowed to write to a repository's protected `development/*`
+branches: humans open pull requests, and Bert-E validates, merges, and
+cascades the change through every affected release line according to a
+branching model called **GitWaterFlow**.
+
+Bert-E runs as a long-lived Flask service that receives GitHub/Bitbucket
+webhooks (and a small REST API), turns them into internal **jobs**, and
+processes those jobs against a local clone of the target repository using
+the `git` CLI and the host's REST API (PR comments, approvals, build
+statuses).
+
+Primary references, already authoritative and not duplicated here:
+- [`bert_e/docs/USER_DOC.md`](../bert_e/docs/USER_DOC.md) — full business rules, message-code table, options/commands table, queue scenarios.
+- [`bert_e/docs/API_DOC.md`](../bert_e/docs/API_DOC.md) — REST API authentication and endpoint reference.
+- [`README.md`](../README.md) — local dev quickstart (codespace, `tox run -e run`, `tox -e tests`).
+- [`CLAUDE.md`](../CLAUDE.md) — notes for running tests (`.venv/bin/pytest`) and cutting a release.
+
+## Repository layout
+
+```
+bert_e/
+├── bert_e.py            # BertE core class: task queue, job processing loop
+├── job.py                # Job base classes (PullRequestJob, CommitJob, ...)
+├── reactor.py            # Generic @bert-e comment command/option registry
+├── settings.py           # YAML settings loading + marshmallow schema
+├── exceptions.py         # Numbered, templated exceptions = bot's outcomes
+├── templates/            # Markdown templates rendered into PR comments
+├── git_host/             # Abstraction over GitHub / Bitbucket / mock
+├── workflow/
+│   ├── gitwaterflow/     # The core merge/branching engine (see below)
+│   ├── pr_utils.py
+│   └── git_utils.py
+├── jobs/                 # API-triggered maintenance jobs (create/delete branch, queues...)
+├── bin/                  # Standalone CLI utility scripts
+├── lib/                  # git wrapper, retry, caching, templating helpers
+├── server/               # Flask app: webhooks, REST API, status/management UI
+├── docs/                 # USER_DOC.md / API_DOC.md (hand-maintained business docs)
+└── tests/                # Functional (test_bert_e.py) + unit tests
+charts/bert-e/            # Helm chart for Kubernetes deployment
+manifests/                # Kustomize manifests
+settings.sample.yml       # Annotated example of a repository's Bert-E config
+```
+
+## Where to go next
+
+- **[Architecture overview](architecture/overview.md)** — how a webhook becomes a merged commit: server, jobs, dispatcher, git host abstraction, settings.
+- **[GitWaterFlow engine](architecture/gitwaterflow.md)** — the branching model, branch taxonomy, the pull-request check pipeline, the merge queue, and Jira integration. Start here before changing merge/business logic.
+- **[Commands and options](architecture/commands-and-options.md)** — how `@bert-e <command>` comments are parsed and dispatched, and how to add new ones.
+- **[Running and testing](operations/running-and-testing.md)** — local dev loop, tox test environments, CI matrix, Docker/Helm deployment, maintenance jobs and CLI scripts.
+- **[API and integrations](operations/api-and-integrations.md)** — REST API surface, auth (GitHub App / Bitbucket OAuth), webhook events, Jira configuration.
+
+## Quick orientation for a new change
+
+1. **Business rule / merge-condition change** → read `architecture/gitwaterflow.md`, then `bert_e/workflow/gitwaterflow/__init__.py` and `bert_e/exceptions.py`; check `bert_e/docs/USER_DOC.md` for the checklist order and message codes, and update it if the observable behavior changes.
+2. **New `@bert-e` command or option** → read `architecture/commands-and-options.md`, then `bert_e/workflow/gitwaterflow/commands.py` and `bert_e/reactor.py`.
+3. **GitHub/Bitbucket API interaction** → `bert_e/git_host/base.py` (abstract interface), then the concrete `github/` or `bitbucket/` implementation, and `bert_e/git_host/mock.py` if you need it reflected in tests.
+4. **Webhook/API/server behavior** → `operations/api-and-integrations.md`, then `bert_e/server/`.
+5. **Maintenance operation (rebuild queues, delete branch, etc.)** → `operations/running-and-testing.md`, then `bert_e/jobs/`.
+
+Always run the relevant tox environment(s) described in
+[`operations/running-and-testing.md`](operations/running-and-testing.md)
+before considering a change complete — most business logic is covered by
+the large functional suite in `bert_e/tests/test_bert_e.py`, run against a
+mock git host.


### PR DESCRIPTION
## Summary

- Adds OpenWiki-generated documentation (`openwiki/`): repository overview,
  architecture notes (git-waterflow, commands/options), and operations
  guidance (API/integrations, running and testing). `CLAUDE.md` and
  `AGENTS.md` now point agents at the OpenWiki quickstart.
- Adds `.github/workflows/openwiki-update.yml`: runs nightly (and on manual
  dispatch). A cheap `check-for-changes` job compares HEAD against
  `openwiki/.last-update.json`'s recorded git head first, so the actual
  update job (Node setup, npm install, `openwiki --update`) only runs when
  there have been commits since the last update. If that produces a diff
  under `openwiki/` (openwiki also runs its own, more thorough no-op check
  internally), it's pushed to an `openwiki/update` branch and a PR is
  opened - or just pushed to the existing PR if one's already open, with
  its description refreshed. Plain `git`/`gh` CLI, no third-party action.
- The commit message and PR description aren't generic boilerplate: they
  capture `openwiki --update --print`'s own natural-language summary of
  what it changed and why, so a nightly update actually explains itself
  ("updated section X because Y") instead of just saying "docs: update
  OpenWiki". Verified end-to-end against a real diff in a throwaway test
  worktree - see the test plan below.
- Updating an existing PR's body goes through the REST API rather than
  `gh pr edit`, which hits a known GraphQL error on repos with legacy
  Projects (classic) enabled (hit this directly while editing this PR's
  own description).
- Adjusts `.github/workflows/main.yaml` to skip the unit/integration suite
  when a change only touches `openwiki/` (docs-only diffs don't exercise
  anything the suite covers).

## Requires

- `ANTHROPIC_API_KEY` repository secret (already set).

## Test plan

- [x] Ran `openwiki --init` locally against this repo to generate the
      committed docs
- [x] Validated both workflow YAML files parse correctly
- [x] Confirmed `scality/bert-e` has no branch protection requiring status
      checks on `main`, so the `paths-ignore` change can't leave a PR stuck
      on a pending required check
- [x] In an isolated git worktree, made a real source change, ran
      `openwiki --update --print`, and confirmed it produced a specific,
      accurate summary naming the exact files/sections it touched and why -
      then confirmed that summary flows correctly into a real
      `git commit -F` commit message
- [ ] First nightly run (or manual `workflow_dispatch`) to confirm the
      check-for-changes gate and PR creation/update behave as expected
      end-to-end in CI
