### PR TITLE
feat: add Claude Code automated PR review

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: review-pr
+description: Review a PR on bert-e (Scality's automated branch merging bot written in Python/Flask)
+argument-hint: <pr-number-or-url>
+disable-model-invocation: true
+allowed-tools: Read, Bash(gh repo view *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh pr comment *), Bash(gh api *), Bash(git diff *), Bash(git log *), Bash(git show *)
+---
+
+# Review GitHub PR
+
+You are an expert code reviewer. Review this PR: $ARGUMENTS
+
+## Determine PR target
+
+Parse `$ARGUMENTS` to extract the repo and PR number:
+
+- If arguments contain `REPO:` and `PR_NUMBER:` (CI mode), use those values directly.
+- If the argument is a GitHub URL (starts with `https://github.com/`), extract `owner/repo` and the PR number from it.
+- If the argument is just a number, use the current repo from `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+## Output mode
+
+- **CI mode** (arguments contain `REPO:` and `PR_NUMBER:`): post inline comments and summary to GitHub.
+- **Local mode** (all other cases): output the review as text directly. Do NOT post anything to GitHub.
+
+## Steps
+
+1. **Fetch PR details:**
+
+```bash
+gh pr view <number> --repo <owner/repo> --json title,body,headRefOid,author,files
+gh pr diff <number> --repo <owner/repo>
+```
+
+2. **Read changed files** to understand the full context around each change (not just the diff hunks).
+
+3. **Analyze the changes** against these criteria:
+
+| Area | What to check |
+|------|---------------|
+| Exception handling | No bare `except:` clauses; catch specific exception types; don't swallow exceptions silently |
+| Async/threading | No blocking calls where async is expected; proper use of locks; no race conditions in queue manipulation |
+| Git host API usage | Correct use of Bitbucket/GitHub API clients in `bert_e/git_host/`; error codes handled; retries applied where appropriate |
+| Branch/queue logic | GitWaterFlow invariants preserved — integration branches created in correct order, queue states consistent |
+| YAML/config | Schema changes in `bert_e/settings.py` or `marshmallow` schemas are backward compatible; new fields have sensible defaults |
+| Jinja2 templates | No template injection risks; template variables escaped where user input is rendered |
+| Logging | Uses Python `logging` module, not `print()`; log levels match severity; no sensitive data (tokens, passwords) logged |
+| Test coverage | New code paths covered by pytest tests in `bert_e/tests/`; mocks used correctly for git host interactions |
+| Dependency changes | `requirements.txt` pin changes are intentional and don't introduce known vulnerabilities |
+| Security | No hardcoded credentials or tokens; secrets read from config/env only; no command injection in `bert_e/lib/simplecmd.py` usage |
+| Breaking changes | Public API, webhook payload format, or settings schema changes are documented |
+
+4. **Deliver your review:**
+
+### If CI mode: post to GitHub
+
+#### Part A: Inline file comments
+
+For each specific issue, post a comment on the exact file and line:
+
+```bash
+gh api -X POST -H "Accept: application/vnd.github+json" "repos/<owner/repo>/pulls/<number>/comments" -f body="Your comment<br><br>— Claude Code" -f path="path/to/file" -F line=<line_number> -f side="RIGHT" -f commit_id="<headRefOid>"
+```
+
+**The command must stay on a single bash line.** Never use newlines in bash commands — use `<br>` for line breaks in comment bodies. Never put `<br>` inside code blocks or suggestion blocks.
+
+Each inline comment must:
+- Be short and direct — say what's wrong, why it's wrong, and how to fix it in 1-3 sentences
+- No filler, no complex words, no long explanations
+- When the fix is a concrete line change (not architectural), include a GitHub suggestion block so the author can apply it in one click:
+  ````
+  ```suggestion
+  corrected-line-here
+  ```
+  ````
+  Only suggest when you can show the exact replacement. For architectural or design issues, just describe the problem.
+  Example with a suggestion block:
+  ```bash
+  gh api ... -f body=$'Missing the shared-guidelines update command.<br><br>\n```suggestion\n/plugin update shared-guidelines@scality-agent-hub\n/plugin update scality-skills@scality-agent-hub\n```\n<br><br>— Claude Code' ...
+  ```
+- When the comment contains a suggestion block, use `$'...'` quoting with `\n` for code fence boundaries. Escape single quotes as `\'` (e.g., `don\'t`)
+- End with: `— Claude Code`
+
+Use the line number from the **new version** of the file (the line number you'd see after the PR is merged), which corresponds to the `line` parameter in the GitHub API.
+
+#### Part B: Summary comment
+
+```bash
+gh pr comment <number> --repo <owner/repo> --body "LGTM<br><br>Review by Claude Code"
+```
+
+**The command must stay on a single bash line.** Never use newlines in bash commands — use `<br>` for line breaks in comment bodies.
+
+Do not describe or summarize the PR. For each issue, state the problem on one line, then list one or more suggestions below it:
+
+```
+- <issue>
+  - <suggestion>
+  - <suggestion>
+```
+
+If no issues: just say "LGTM". End with: `Review by Claude Code`
+
+### If local mode: output the review as text
+
+Do NOT post anything to GitHub. Instead, output the review directly as text.
+
+For each issue found, output:
+
+```
+**<file_path>:<line_number>** — <what's wrong and how to fix it>
+```
+
+When the fix is a concrete line change, include a fenced code block showing the suggested replacement.
+
+At the end, output a summary section listing all issues. If no issues: just say "LGTM".
+
+End with: `Review by Claude Code`
+
+## What NOT to do
+
+- Do not comment on markdown formatting preferences
+- Do not suggest refactors unrelated to the PR's purpose
+- Do not praise code — only flag problems or stay silent
+- If no issues are found, post only a summary saying "LGTM"
+- Do not flag style issues already covered by the project's linter (flake8, pylint)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,14 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    uses: scality/workflows/.github/workflows/claude-code-review.yml@v2
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
+      CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,16 @@
+# bert-e
+
+This is a **Python automated branch merging bot** (Bert-E). It implements the GitWaterFlow branching model for Scality repositories. It contains:
+
+- Git host integrations (`bert_e/git_host/`) — Bitbucket and GitHub API clients
+- Workflow engine (`bert_e/workflow/`) — GitWaterFlow logic for branch queue management
+- Job handlers (`bert_e/jobs/`) — discrete operations (create/delete branches, rebuild queues)
+- Flask web server (`bert_e/server/`) — webhook receiver and dashboard UI
+- Utility libraries (`bert_e/lib/`) — git, retry, schema validation, Jira integration
+- Test suite (`bert_e/tests/`) — pytest-based, uses mocks for git host interactions
+
+Tech stack: Python 3.10+, Flask, PyYAML, requests, marshmallow, pytest. No Node.js or git-based shared libraries.
+
 # bert-e — Claude Code notes
 
 ## Running tests


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/review-pr/SKILL.md` — a repo-specific `/review-pr` skill with Python/Flask review criteria tailored to bert-e (exception handling, GitWaterFlow invariants, git host API usage, Jinja2 template safety, logging hygiene, test coverage)
- Adds `.github/workflows/review.yml` — GitHub Actions workflow that triggers Claude Code review on every PR via `scality/workflows/.github/workflows/claude-code-review.yml@v2`
- Prepends a repo context block to `CLAUDE.md` describing bert-e's architecture and tech stack for Claude Code

## Test plan

- [ ] Ensure the repo has access to the four org-level secrets: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`
- [ ] Open a test PR and verify the review workflow triggers and posts inline comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)