### PR TITLE
feat: implement /status command with full PR status report (BERTE-539)

### DIFF
--- a/bert_e/templates/status_report.md
+++ b/bert_e/templates/status_report.md
@@ -3,7 +3,7 @@
 check    | status
 ---------|--------
 {% for item in status -%}
-:arrow_right: **{{status[item].display_name}}** | {% if status[item].pass %}:sunny:{% else %}:exclamation:{% endif %}
+:arrow_right: **{{status[item].display_name}}** | {% if status[item].pass %}:sunny:{% else %}:exclamation: {{ status[item].details | join(' — ') }}{% endif %}
 {% endfor %}
 
 {% else %}

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -2644,6 +2644,347 @@ admins:
                         ],
                         backtrace=True)
 
+    def test_status_command_reports_missing_approvals(self):
+        """Status report shows failing approval check when no approvals."""
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        # First run lets send_greetings post the InitMessage; the status
+        # comment must be newer than that greeting for handle_comments.
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'], backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('approvals', report)
+        approvals_item = report['approvals']
+        self.assertFalse(getattr(approvals_item, 'pass'))
+        self.assertTrue(approvals_item.details)
+
+    def test_status_command_approvals_pass_when_bypassed(self):
+        """Status report shows passing approvals when bypassed."""
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        pr_admin = self.admin_bb.get_pull_request(pull_request_id=pr.id)
+        # Admin (project leader) approves
+        pr_admin.approve()
+        # First run lets send_greetings post the InitMessage; the status
+        # comment must be newer than that greeting for handle_comments.
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check',
+                                        'bypass_author_approval',
+                                        'bypass_leader_approval',
+                                        'bypass_peer_approval'],
+                        backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('approvals', report)
+        self.assertTrue(getattr(report['approvals'], 'pass'))
+
+    def test_status_command_history_check(self):
+        """Status report includes a history check once integration branches exist,
+        and correctly detects when a reset is needed.
+        """
+        feature_branch = 'bugfix/TEST-00001'
+        integration_branch = 'w/5.1/bugfix/TEST-00001'
+        pr = self.create_pr(feature_branch, 'development/4.3')
+
+        # Create integration branches (stops at approval check)
+        self.handle(pr.id, options=['bypass_jira_check'])
+
+        # Status should show history is clean
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'], backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('history', report)
+        self.assertTrue(getattr(report['history'], 'pass'))
+
+        # Add a commit directly to an integration branch (history mismatch)
+        self.gitrepo.cmd('git pull')
+        add_file_to_branch(self.gitrepo, integration_branch,
+                           'file_added_on_int_branch')
+
+        # Status should now report that a reset may be needed
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'], backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('history', report)
+        self.assertFalse(getattr(report['history'], 'pass'))
+
+    def test_status_command_builds_bypassed(self):
+        """Status report shows builds as bypassed when bypass_build_status."""
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check',
+                                        'bypass_build_status',
+                                        'bypass_author_approval',
+                                        'bypass_peer_approval'],
+                        backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('builds', report)
+        self.assertTrue(getattr(report['builds'], 'pass'))
+        self.assertIn('bypassed', report['builds'].details)
+
+    def test_status_command_jira_missing_key(self):
+        """Status report: failing fix-versions when branch has no Jira key."""
+        pr = self.create_pr('bugfix/my-feature', 'development/4.3')
+        # First run triggers send_greetings; MissingJiraId is caught silently.
+        self.handle(pr.id)
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('fix_versions', report)
+        self.assertFalse(getattr(report['fix_versions'], 'pass'))
+        self.assertIn('missing Jira issue id in branch name',
+                      report['fix_versions'].details)
+
+    def test_status_command_no_build_key(self):
+        """Status report omits builds check when no build_key is set."""
+        settings = DEFAULT_SETTINGS.replace('build_key: pre-merge',
+                                            'build_key: ""')
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'], settings=settings)
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'],
+                        settings=settings, backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertNotIn('builds', report)
+
+    def test_status_command_builds_successful(self):
+        """Status report shows builds passing when all builds SUCCESSFUL."""
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        self.gitrepo.cmd('git fetch --prune')
+        wbranch_refs = self.gitrepo.cmd(
+            'git branch -r --list origin/w/*/bugfix/TEST-00001'
+        ).strip().split()
+        for ref in wbranch_refs:
+            sha = self.gitrepo.cmd('git rev-parse %s' % ref).strip()
+            self.set_build_status(sha, 'SUCCESSFUL')
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'], backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('builds', report)
+        self.assertTrue(getattr(report['builds'], 'pass'))
+
+    def test_status_command_leader_author_unapproved(self):
+        """Status report: extra leader approval when author is a leader."""
+        settings = DEFAULT_SETTINGS.replace(
+            'project_leaders:\n  - {admin}',
+            'project_leaders:\n  - {admin}\n  - {contributor}'
+        )
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'], settings=settings)
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'],
+                        settings=settings, backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('approvals', report)
+        self.assertFalse(getattr(report['approvals'], 'pass'))
+
+    def test_status_command_jira_issue_not_found(self):
+        """Status report: failing fix-versions when Jira issue not found."""
+        from bert_e.lib import jira as jira_lib
+        from bert_e import exceptions as bert_e_exns
+
+        class _JiraIssueNotFoundMock:
+            def __init__(self, account_url, issue_id, email, token):
+                raise bert_e_exns.JiraIssueNotFound(
+                    issue=issue_id, active_options=[])
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        original = jira_lib.JiraIssue
+        jira_lib.JiraIssue = _JiraIssueNotFoundMock
+        try:
+            with self.assertRaises(exns.StatusReport) as ctx:
+                self.handle(pr.id, backtrace=True)
+        finally:
+            jira_lib.JiraIssue = original
+        report = ctx.exception.kwargs['status']
+        self.assertIn('fix_versions', report)
+        self.assertFalse(getattr(report['fix_versions'], 'pass'))
+        self.assertIn('Jira issue not found', report['fix_versions'].details)
+
+    def test_status_command_jira_unreachable(self):
+        """Status report omits fix-versions when Jira is unreachable."""
+        import requests.exceptions
+        from bert_e.lib import jira as jira_lib
+
+        class _JiraUnreachableMock:
+            def __init__(self, account_url, issue_id, email, token):
+                raise requests.exceptions.ConnectionError(
+                    "Jira unreachable")
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        original = jira_lib.JiraIssue
+        jira_lib.JiraIssue = _JiraUnreachableMock
+        try:
+            with self.assertRaises(exns.StatusReport) as ctx:
+                self.handle(pr.id, backtrace=True)
+        finally:
+            jira_lib.JiraIssue = original
+        report = ctx.exception.kwargs['status']
+        self.assertNotIn('fix_versions', report)
+
+    def test_status_command_partial_report_on_clone_failure(self):
+        """Status report returns approvals even when git clone fails."""
+        import bert_e.workflow.gitwaterflow.commands as cmd_mod
+
+        def _fail_clone(job):
+            raise RuntimeError("clone failed")
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        original = cmd_mod.clone_git_repo
+        cmd_mod.clone_git_repo = _fail_clone
+        try:
+            with self.assertRaises(exns.StatusReport) as ctx:
+                self.handle(pr.id, options=['bypass_jira_check'],
+                            backtrace=True)
+        finally:
+            cmd_mod.clone_git_repo = original
+        report = ctx.exception.kwargs['status']
+        self.assertIn('approvals', report)
+        self.assertNotIn('builds', report)
+        self.assertNotIn('history', report)
+
+    def test_status_command_approve_option_missing_peers(self):
+        """Status report: approve option adds author to approvals set but
+        peer approvals are still required and reported as missing."""
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check', 'approve'],
+                        backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('approvals', report)
+        self.assertFalse(getattr(report['approvals'], 'pass'))
+        self.assertTrue(any('peer' in d for d in report['approvals'].details))
+
+    def test_status_command_change_requests(self):
+        """Status report shows change requests in approval failure details."""
+        if self.args.git_host == 'bitbucket':
+            self.skipTest("change requests not supported on bitbucket")
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr_admin = self.admin_bb.get_pull_request(pull_request_id=pr.id)
+        pr_admin.request_changes()
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'], backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('approvals', report)
+        self.assertFalse(getattr(report['approvals'], 'pass'))
+        self.assertTrue(
+            any('changes requested' in d for d in report['approvals'].details))
+
+    def test_status_command_jira_partial_config(self):
+        """Status report omits fix-versions when Jira email is not set."""
+        settings = DEFAULT_SETTINGS.replace(
+            'jira_email: dummy@mail.com', 'jira_email: ""')
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'], settings=settings)
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, settings=settings, backtrace=True)
+        self.assertNotIn('fix_versions', ctx.exception.kwargs['status'])
+
+    def test_status_command_disable_version_checks(self):
+        """Status report omits fix-versions when disable_version_checks is set."""  # noqa
+        settings = DEFAULT_SETTINGS + 'disable_version_checks: true\n'
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'], settings=settings)
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, settings=settings, backtrace=True)
+        self.assertNotIn('fix_versions', ctx.exception.kwargs['status'])
+
+    def test_status_command_jira_no_reference(self):
+        """Status report omits fix-versions when the branch has no Jira
+        reference but ticketless PRs are allowed (check_issue_reference
+        returns False)."""
+        import bert_e.workflow.gitwaterflow.jira as jira_mod
+
+        def _return_no_ref(job):
+            return False
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        original = jira_mod.check_issue_reference
+        jira_mod.check_issue_reference = _return_no_ref
+        try:
+            with self.assertRaises(exns.StatusReport) as ctx:
+                self.handle(pr.id, backtrace=True)
+        finally:
+            jira_mod.check_issue_reference = original
+        self.assertNotIn('fix_versions', ctx.exception.kwargs['status'])
+
+    def test_status_command_jira_correct_versions(self):
+        """Status report shows passing fix-versions when Jira check succeeds."""  # noqa
+        import bert_e.workflow.gitwaterflow.jira as jira_mod
+
+        class _MockIssue:
+            pass
+
+        pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+        pr.add_comment('@%s status' % self.args.robot_username)
+        original_get = jira_mod.get_jira_issue
+        original_check = jira_mod.check_fix_versions
+        jira_mod.get_jira_issue = lambda job: _MockIssue()
+        jira_mod.check_fix_versions = lambda job, issue: None
+        try:
+            with self.assertRaises(exns.StatusReport) as ctx:
+                self.handle(pr.id, backtrace=True)
+        finally:
+            jira_mod.get_jira_issue = original_get
+            jira_mod.check_fix_versions = original_check
+        report = ctx.exception.kwargs['status']
+        self.assertIn('fix_versions', report)
+        self.assertTrue(getattr(report['fix_versions'], 'pass'))
+
+    def test_status_command_robot_commit_in_history(self):
+        """Status report: robot-authored commits on integration branches are
+        not flagged as foreign (history passes)."""
+        feature_branch = 'bugfix/TEST-00001'
+        integration_branch = 'w/5.1/bugfix/TEST-00001'
+
+        pr = self.create_pr(feature_branch, 'development/4.3')
+        self.handle(pr.id, options=['bypass_jira_check'])
+
+        self.gitrepo.cmd('git fetch --prune')
+        self.gitrepo.cmd('git checkout ' + integration_branch)
+        # An empty commit has no diff, so git show --pretty="%aN" returns only
+        # the author name — which is what rev.author compares against robot.
+        self.gitrepo.cmd(
+            'git commit --allow-empty -m "robot commit" '
+            '--author="%s <robot@nowhere.com>"' % self.args.robot_username
+        )
+        self.gitrepo.cmd('git pull || exit 0')
+        self.gitrepo.cmd(
+            'git push --set-upstream origin ' + integration_branch)
+
+        pr.add_comment('@%s status' % self.args.robot_username)
+        with self.assertRaises(exns.StatusReport) as ctx:
+            self.handle(pr.id, options=['bypass_jira_check'], backtrace=True)
+        report = ctx.exception.kwargs['status']
+        self.assertIn('history', report)
+        self.assertTrue(getattr(report['history'], 'pass'))
+
     def test_bypass_options(self):
         # test bypass all approvals through an incorrect bitbucket comment
         pr = self.create_pr('bugfix/TEST-00001', 'development/4.3')

--- a/bert_e/workflow/gitwaterflow/commands.py
+++ b/bert_e/workflow/gitwaterflow/commands.py
@@ -18,6 +18,8 @@ The module holds the implementation of all commands/options users can send
 BertE through comments in the pull requests.
 
 """
+import logging
+
 from bert_e.exceptions import (
     CommandNotImplemented, LossyResetWarning, ResetComplete, HelpMessage,
     StatusReport, IncorrectCommandSyntax
@@ -25,6 +27,239 @@ from bert_e.exceptions import (
 from bert_e.reactor import Reactor
 from .integration import get_integration_branches
 from ..git_utils import clone_git_repo, push
+
+LOG = logging.getLogger(__name__)
+
+
+class _StatusItem:
+    """A single row in the pull request status report."""
+
+    def __init__(self, display_name, passed, details=None):
+        self.display_name = display_name
+        setattr(self, 'pass', passed)
+        self.details = details or []
+
+
+def _check_approvals_status(job):
+    """Return a _StatusItem reflecting the current approval state."""
+    from .utils import (bypass_peer_approval, bypass_leader_approval,
+                        bypass_author_approval)
+
+    required_peer = job.settings.required_peer_approvals
+    required_leader = job.settings.required_leader_approvals
+    robot = job.settings.robot
+
+    peer_count = required_peer if bypass_peer_approval(job) else 0
+    leader_count = required_leader if bypass_leader_approval(job) else 0
+    author_ok = (not job.settings.need_author_approval or
+                 bypass_author_approval(job) or
+                 job.settings.approve)
+
+    if (author_ok and
+            peer_count >= required_peer and
+            leader_count >= required_leader and
+            not job.settings.unanimity):
+        return _StatusItem('Approvals', True)
+
+    participants = set(job.pull_request.get_participants()) - {robot}
+    approvals = set(job.pull_request.get_approvals())
+    if job.settings.approve:
+        approvals.add(job.pull_request.author)
+
+    leaders = set(job.settings.project_leaders)
+    author_ok = author_ok or job.pull_request.author in approvals
+    leader_count += len(approvals & leaders)
+    if (job.pull_request.author in leaders and
+            job.pull_request.author not in approvals):
+        leader_count += 1
+
+    peer_count += len(approvals - {job.pull_request.author})
+    change_requests = set(job.pull_request.get_change_requests())
+    unanimity = job.settings.unanimity
+    is_unanimous = (approvals - {robot}) == participants
+
+    details = []
+    if not author_ok:
+        details.append("author approval required")
+    missing_leaders = required_leader - leader_count
+    if missing_leaders > 0:
+        unapproved = sorted(str(u) for u in leaders - approvals)
+        details.append(
+            "{} leader approval(s) missing{}".format(
+                missing_leaders,
+                " (from: {})".format(', '.join(unapproved)) if unapproved
+                else ""
+            )
+        )
+    missing_peers = required_peer - peer_count
+    if missing_peers > 0:
+        details.append("{} peer approval(s) missing".format(missing_peers))
+    if unanimity and not is_unanimous:
+        details.append("unanimity required but not reached")
+    if change_requests:
+        details.append(
+            "changes requested by: {}".format(
+                ', '.join(sorted(change_requests)))
+        )
+
+    return _StatusItem('Approvals', not details, details=details)
+
+
+def _check_builds_status(job):
+    """Return a _StatusItem for integration branch build status, or None if
+    no integration branches exist or no build key is configured.
+    """
+    key = job.settings.build_key
+    if not key:
+        return None
+
+    from .utils import bypass_build_status
+    wbranches = list(get_integration_branches(job))
+    if not wbranches:
+        return None
+
+    if bypass_build_status(job):
+        return _StatusItem('Integration builds', True, ['bypassed'])
+
+    ordered = {
+        'SUCCESSFUL': 0, 'INPROGRESS': 1,
+        'NOTSTARTED': 2, 'STOPPED': 3, 'FAILED': 4,
+    }
+    worst_rank = 0
+    worst_branch = None
+    worst_state = 'SUCCESSFUL'
+    for branch in wbranches:
+        state = job.project_repo.get_build_status(
+            branch.get_latest_commit(), key)
+        rank = ordered.get(state, 5)
+        if rank > worst_rank:
+            worst_rank = rank
+            worst_branch = branch
+            worst_state = state
+
+    if worst_state == 'SUCCESSFUL':
+        return _StatusItem('Integration builds', True)
+    return _StatusItem(
+        'Integration builds', False,
+        details=["{}: {}".format(worst_branch.name, worst_state)]
+    )
+
+
+def _check_fix_versions_status(job):
+    """Return a _StatusItem for Jira fix-version correctness, or None if
+    Jira is not configured or version checks are disabled.
+    """
+    from .utils import bypass_jira_check
+    from bert_e import exceptions as exns
+
+    if bypass_jira_check(job):
+        return _StatusItem('Fix versions', True, ['bypassed'])
+
+    if not all([job.settings.jira_keys,
+                job.settings.jira_email,
+                job.settings.jira_account_url]):
+        return None
+
+    if job.settings.disable_version_checks:
+        return None
+
+    from jira.exceptions import JIRAError
+    import requests.exceptions as requests_exc
+    from .jira import check_issue_reference, get_jira_issue, check_fix_versions
+    try:
+        has_ref = check_issue_reference(job)
+    except exns.MissingJiraId:
+        return _StatusItem('Fix versions', False,
+                           details=['missing Jira issue id in branch name'])
+
+    if not has_ref:
+        return None
+
+    try:
+        issue = get_jira_issue(job)
+        check_fix_versions(job, issue)
+        return _StatusItem('Fix versions', True)
+    except exns.IncorrectFixVersion as exc:
+        details = [
+            "expected: {}".format(
+                ', '.join(exc.kwargs.get('expect_versions', []))),
+            "found: {}".format(
+                ', '.join(exc.kwargs.get('issue_versions', []))),
+        ]
+        return _StatusItem('Fix versions', False, details=details)
+    except exns.JiraIssueNotFound:
+        return _StatusItem('Fix versions', False,
+                           details=['Jira issue not found'])
+    except (JIRAError, requests_exc.RequestException):
+        LOG.warning("Fix-version status check failed: Jira unreachable",
+                    exc_info=True)
+        return None
+
+
+def _has_foreign_commit(branch, robot):
+    """Return True if the integration branch contains a commit that is not
+    from the feature branch or the robot — i.e. one that would be lost on
+    a reset.
+    """
+    src, dst = branch.src_branch, branch.dst_branch
+    feature = set(src.get_commit_diff(dst))
+    for rev in reversed(list(branch.get_commit_diff(dst))):
+        if rev in feature:
+            continue
+        if rev.author == robot:
+            continue
+        if len(rev.parents) == 1:
+            parent = rev.parents[0]
+            if parent in feature or dst.includes_commit(parent):
+                feature.add(rev)
+                continue
+        return True
+    return False
+
+
+def _check_history_status(job):
+    """Return a _StatusItem indicating whether a reset may be needed, or
+    None if no integration branches exist yet.
+    """
+    wbranches = list(get_integration_branches(job))
+    if not wbranches:
+        return None
+
+    for branch in wbranches:
+        if _has_foreign_commit(branch, job.settings.robot):
+            return _StatusItem('History', False, ['reset may be needed'])
+
+    return _StatusItem('History', True)
+
+
+def _build_status_report(job):
+    """Collect all available status checks for the pull request."""
+    from .branches import build_branch_cascade
+
+    report = {}
+    report['approvals'] = _check_approvals_status(job)
+
+    try:
+        clone_git_repo(job)
+        build_branch_cascade(job)
+    except Exception:
+        LOG.warning("Status report: git clone/cascade failed, "
+                    "returning partial report", exc_info=True)
+        return report
+
+    builds = _check_builds_status(job)
+    if builds is not None:
+        report['builds'] = builds
+
+    fix_versions = _check_fix_versions_status(job)
+    if fix_versions is not None:
+        report['fix_versions'] = fix_versions
+
+    history = _check_history_status(job)
+    if history is not None:
+        report['history'] = history
+
+    return report
 
 
 @Reactor.option(default=set())
@@ -57,8 +292,9 @@ def print_help(job, *args):
 
 @Reactor.command
 def status(job, *args):
-    """Print Bert-E's current status in the pull request ```TBA```"""
-    raise StatusReport(status={}, active_options=job.active_options)
+    """Print Bert-E's current status in the pull request."""
+    report = _build_status_report(job)
+    raise StatusReport(status=report, active_options=job.active_options)
 
 
 @Reactor.command("build", "Re-start a fresh build ```TBA```")
@@ -82,44 +318,7 @@ def _reset(job, force=False):
 
     lossy_reset = None
     for branch in wbranches:
-        src, dst = branch.src_branch, branch.dst_branch
-
-        # Build a 'feature' set that is ultimately going to contain commits
-        # from the current feature branch + those from potentially earlier
-        # (pre-rebase) versions of the feature branch
-        feature = set(src.get_commit_diff(dst))
-
-        # Analyse commits from the integration branch
-        wcommits = reversed(list(branch.get_commit_diff(dst)))
-        for rev in wcommits:
-            if rev in feature:
-                continue
-
-            if rev.author == job.settings.robot:
-                continue
-
-            # At this point, we want to avoid blocking on commits that were
-            # part of the feature branch in the past. Given the branching
-            # algorithm:
-            # - if the commit is not a merge (has only one parent)
-            # - and if it is based on either a commit from the development
-            #   branch or the current 'feature' set.
-            #
-            # Then this commit once belonged to the feature branch,
-            # so we add it to the 'feature' set.
-            if len(rev.parents) == 1:
-                parent = rev.parents[0]
-                if parent in feature or dst.includes_commit(parent):
-                    feature.add(rev)
-                    continue
-
-            # If we reach this point:
-            #
-            # The current commit is from the PR author, and it is either a
-            # merge commit (conflict resolution) or it was made from the
-            # integration branch.
-            #
-            # Deleting it would be a loss for the user.
+        if _has_foreign_commit(branch, job.settings.robot):
             lossy_reset = LossyResetWarning(active_options=job.active_options)
 
     if lossy_reset and not force:


### PR DESCRIPTION
## Summary

- Replaces the stub `/status` command with a real implementation that reports the live state of all merge prerequisites
- Reports: approvals (with details on missing approvals), integration branch build results, Jira fix-version correctness, and integration history health
- Each check is shown as a table row with a pass/fail indicator and inline details on failure

## Details

**`commands.py`**
- `_StatusItem`: lightweight data class for a single status row (uses `setattr(self, 'pass', ...)` because `pass` is a Python keyword)
- `_check_approvals_status`: mirrors the `check_approvals` enforcement logic to report who/what is blocking approval
- `_check_builds_status`: reports worst build state across integration branches; skipped if no branches or no build key configured
- `_check_fix_versions_status`: checks Jira fix versions; skipped if Jira is not configured or checks are disabled
- `_check_history_status`: detects integration branch history drift (same logic as `_reset`); skipped if no integration branches
- `_build_status_report`: orchestrates all checks after cloning the repo and building the branch cascade

**`status_report.md`**: updated template to render inline failure details next to the `:exclamation:` indicator

## Test plan

- [ ] `test_status_command_reports_missing_approvals` — status shows failing approvals when no approvals given
- [ ] `test_status_command_approvals_pass_when_bypassed` — status shows passing approvals when bypass options are set
- [ ] `test_status_command_history_check` — status includes history check and correctly detects when a reset is needed
- [ ] Full `TestBertE` suite passes (206 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)