### PR TITLE
fix: dev branch must skip past a pre-GA hotfix's reserved micro version (BERTE-609)

### DIFF
--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -520,6 +520,12 @@ class QuickTest(unittest.TestCase):
         Scenario: dev/9.5, hotfix/10.0.0 (pre-GA), dev/10.0, dev/10.
         Note: in the rename-based workflow hotfix/10.0.0 replaces dev/10.0;
         but both can coexist when the hotfix is branched off before GA.
+
+        hotfix/10.0.0 permanently reserves version 10.0.0(.X) the moment
+        it is branched, GA or not: any later "10.0.0" tag on dev/10.0 would
+        collide with the hotfix line, since they are different commits.
+        So dev/10.0 must target 10.0.1, not 10.0.0, whether or not the
+        hotfix has GA'd yet.
         """
         destination = 'development/9.5'
         branches = OrderedDict({
@@ -528,17 +534,22 @@ class QuickTest(unittest.TestCase):
             3: {'name': 'development/10.0', 'ignore': False},
             4: {'name': 'development/10', 'ignore': False},
         })
-        # Pre-GA: no tags for 10.x yet
-        # dev/10.0 targets 10.0.0, dev/10 targets 10.1.0 (latest_minor=0)
+        # Pre-GA: no tags for 10.x yet.
+        # hotfix/10.0.0 (still 10.0.0.0 pre-GA) reserves 10.0.0, so
+        # dev/10.0 targets 10.0.1; dev/10 targets 10.1.0 (latest_minor=0).
         tags = ['9.5.2']
-        fixver = ['9.5.3', '10.0.0', '10.1.0']
-        self.finalize_cascade(branches, tags, destination, fixver)
+        fixver = ['9.5.3', '10.0.1', '10.1.0']
+        c = self.finalize_cascade(branches, tags, destination, fixver)
+        self.assertEqual(c._phantom_hotfixes[0].version, '10.0.0.0')
 
-        # Post-GA: tag 10.0.0.0 advances dev/10.0 to target 10.0.1
-        # dev/10 still targets 10.1.0 (latest_minor=0 unchanged)
+        # Post-GA: tag 10.0.0.0 lands — dev/10.0 still targets 10.0.1
+        # (already reserved pre-GA); dev/10 still targets 10.1.0
+        # (latest_minor=0 unchanged). The hotfix's own version advances
+        # to 10.0.0.1.
         tags = ['9.5.2', '10.0.0.0']
         fixver = ['9.5.3', '10.0.1', '10.1.0']
-        self.finalize_cascade(branches, tags, destination, fixver)
+        c = self.finalize_cascade(branches, tags, destination, fixver)
+        self.assertEqual(c._phantom_hotfixes[0].version, '10.0.0.1')
 
     def test_phantom_hotfix_hfrev_updated_by_ga_tag(self):
         """Phantom hotfix hfrev and version must be updated by update_versions.

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -1170,6 +1170,18 @@ class BranchCascade(object):
                         version_tuple[1] == minor and
                         version_tuple[2] is not None)
                 ]
+
+                # Also include phantom hotfix branches (stored separately to
+                # avoid corrupting the cascade) so that e.g. hotfix/10.0.0
+                # advances dev/10.0's latest_micro to 0 even without a GA
+                # tag: the hotfix branch permanently reserves that micro
+                # version the moment it is cut, so dev/10.0 must target
+                # 10.0.1, not 10.0.0.
+                micros.extend(
+                    hf.micro for hf in self._phantom_hotfixes
+                    if hf.major == major and hf.minor == minor
+                )
+
                 if micros:
                     minor_branch.latest_micro = max(micros)
 


### PR DESCRIPTION
## Summary

- A pre-GA hotfix branch (e.g. `hotfix/10.0.0`) permanently reserves its `X.Y.Z` version the moment it is cut: every version it can ever produce is `X.Y.Z.<hfrev>` (`.0` pre-GA, `.1`+ post-GA), never a bare `X.Y.Z`. The parent dev branch (`development/10.0`) must therefore target `X.Y.(Z+1)`, not `X.Y.Z`, or a later `X.Y.Z` tag cut from the dev branch would collide with the hotfix line while describing different code.
- `_update_major_versions()` already implements this rule for major-only dev branches (`development/10` correctly skips past `hotfix/10.0.0` to target `10.1.0`), but the equivalent minor-branch path ignored phantom hotfix branches when computing `latest_micro`. This change folds phantom hotfix micros into that computation too, mirroring the existing major-only handling.
- Updated `test_branch_cascade_2digit_with_pre_ga_hotfix` to assert the corrected expectation (`development/10.0` → `10.0.1`, not `10.0.0`) both pre- and post-GA, and added assertions on the hotfix's own version (`10.0.0.0` → `10.0.0.1`) to make the pairing explicit.

Ref: [BERTE-609](https://scality.atlassian.net/browse/BERTE-609)

## Test plan

- [x] `test_branch_cascade_2digit_with_pre_ga_hotfix` updated and passing
- [x] Full `QuickTest` cascade/hotfix/phantom test class passing (29 tests)
- [x] Verified unrelated `TestQueueing`/`TaskQueueTests` failures pre-exist on unmodified `main` (require the full mock-server CLI harness, not bare pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BERTE-609]: https://scality.atlassian.net/browse/BERTE-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ