### PR TITLE
fix: dev branch must skip past a pre-GA hotfix's reserved micro version (BERTE-609)

### DIFF
--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -551,6 +551,31 @@ class QuickTest(unittest.TestCase):
         c = self.finalize_cascade(branches, tags, destination, fixver)
         self.assertEqual(c._phantom_hotfixes[0].version, '10.0.0.1')
 
+    def test_branch_cascade_pre_ga_hotfix_after_prior_releases(self):
+        """Pre-GA hotfix cut *after* prior micro releases were already
+        tagged on the same line.
+
+        Scenario: dev/9.5 already has 9.5.0, 9.5.1, 9.5.2 tagged (so its
+        tag-driven `_next_micro` is already resolved to 3), and only then
+        is hotfix/9.5.3 branched off it, pre-GA. This is the common,
+        realistic hotfix scenario (patching an already-released line)
+        as opposed to test_branch_cascade_2digit_with_pre_ga_hotfix's
+        edge case where no prior tag exists at all.
+
+        dev/9.5 must still skip past the now-reserved 9.5.3 and target
+        9.5.4, even though _next_micro was already computed to 3 by the
+        tags before the hotfix branch ever existed.
+        """
+        destination = 'development/9.5'
+        branches = OrderedDict({
+            1: {'name': 'development/9.5', 'ignore': False},
+            2: {'name': 'hotfix/9.5.3', 'ignore': True},
+        })
+        tags = ['9.5.0', '9.5.1', '9.5.2']
+        fixver = ['9.5.4']
+        c = self.finalize_cascade(branches, tags, destination, fixver)
+        self.assertEqual(c._phantom_hotfixes[0].version, '9.5.3.0')
+
     def test_phantom_hotfix_hfrev_updated_by_ga_tag(self):
         """Phantom hotfix hfrev and version must be updated by update_versions.
 

--- a/bert_e/tests/test_bert_e.py
+++ b/bert_e/tests/test_bert_e.py
@@ -520,6 +520,12 @@ class QuickTest(unittest.TestCase):
         Scenario: dev/9.5, hotfix/10.0.0 (pre-GA), dev/10.0, dev/10.
         Note: in the rename-based workflow hotfix/10.0.0 replaces dev/10.0;
         but both can coexist when the hotfix is branched off before GA.
+
+        hotfix/10.0.0 permanently reserves version 10.0.0(.X) the moment
+        it is branched, GA or not: any later "10.0.0" tag on dev/10.0 would
+        collide with the hotfix line, since they are different commits.
+        So dev/10.0 must target 10.0.1, not 10.0.0, whether or not the
+        hotfix has GA'd yet.
         """
         destination = 'development/9.5'
         branches = OrderedDict({
@@ -528,17 +534,22 @@ class QuickTest(unittest.TestCase):
             3: {'name': 'development/10.0', 'ignore': False},
             4: {'name': 'development/10', 'ignore': False},
         })
-        # Pre-GA: no tags for 10.x yet
-        # dev/10.0 targets 10.0.0, dev/10 targets 10.1.0 (latest_minor=0)
+        # Pre-GA: no tags for 10.x yet.
+        # hotfix/10.0.0 (still 10.0.0.0 pre-GA) reserves 10.0.0, so
+        # dev/10.0 targets 10.0.1; dev/10 targets 10.1.0 (latest_minor=0).
         tags = ['9.5.2']
-        fixver = ['9.5.3', '10.0.0', '10.1.0']
-        self.finalize_cascade(branches, tags, destination, fixver)
+        fixver = ['9.5.3', '10.0.1', '10.1.0']
+        c = self.finalize_cascade(branches, tags, destination, fixver)
+        self.assertEqual(c._phantom_hotfixes[0].version, '10.0.0.0')
 
-        # Post-GA: tag 10.0.0.0 advances dev/10.0 to target 10.0.1
-        # dev/10 still targets 10.1.0 (latest_minor=0 unchanged)
+        # Post-GA: tag 10.0.0.0 lands — dev/10.0 still targets 10.0.1
+        # (already reserved pre-GA); dev/10 still targets 10.1.0
+        # (latest_minor=0 unchanged). The hotfix's own version advances
+        # to 10.0.0.1.
         tags = ['9.5.2', '10.0.0.0']
         fixver = ['9.5.3', '10.0.1', '10.1.0']
-        self.finalize_cascade(branches, tags, destination, fixver)
+        c = self.finalize_cascade(branches, tags, destination, fixver)
+        self.assertEqual(c._phantom_hotfixes[0].version, '10.0.0.1')
 
     def test_phantom_hotfix_hfrev_updated_by_ga_tag(self):
         """Phantom hotfix hfrev and version must be updated by update_versions.

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -1208,6 +1208,7 @@ class BranchCascade(object):
                 if dev_branch.has_minor:
                     # Use the tracked next micro version if available,
                     # otherwise use the micro+1 if this is a three-digit branch
+                    own_version = False
                     if (hasattr(dev_branch, '_next_micro') and
                             dev_branch._next_micro is not None):
                         next_micro = dev_branch._next_micro
@@ -1217,11 +1218,29 @@ class BranchCascade(object):
                             dev_branch.micro)
                         self.target_versions.append(version_current)
                         next_micro = dev_branch.micro
+                        own_version = True
                     else:
                         if hasattr(dev_branch, 'latest_micro'):
                             next_micro = dev_branch.latest_micro + 1
                         else:
                             next_micro = 0
+
+                    if not own_version:
+                        # _next_micro is tag-driven and may have been
+                        # computed before a pre-GA hotfix branch existed.
+                        # A phantom hotfix permanently reserves its micro
+                        # version, so never let a stale _next_micro (or
+                        # latest_micro fallback) collide with it.
+                        reserved_micros = [
+                            hf.micro for hf in self._phantom_hotfixes
+                            if hf.major == dev_branch.major and
+                            hf.minor == dev_branch.minor
+                        ]
+                        if reserved_micros:
+                            next_micro = max(
+                                next_micro, max(reserved_micros) + 1
+                            )
+
                     version_str = '%d.%d.%d' % (
                         dev_branch.major, dev_branch.minor, next_micro
                     )

--- a/bert_e/workflow/gitwaterflow/branches.py
+++ b/bert_e/workflow/gitwaterflow/branches.py
@@ -1170,6 +1170,18 @@ class BranchCascade(object):
                         version_tuple[1] == minor and
                         version_tuple[2] is not None)
                 ]
+
+                # Also include phantom hotfix branches (stored separately to
+                # avoid corrupting the cascade) so that e.g. hotfix/10.0.0
+                # advances dev/10.0's latest_micro to 0 even without a GA
+                # tag: the hotfix branch permanently reserves that micro
+                # version the moment it is cut, so dev/10.0 must target
+                # 10.0.1, not 10.0.0.
+                micros.extend(
+                    hf.micro for hf in self._phantom_hotfixes
+                    if hf.major == major and hf.minor == minor
+                )
+
                 if micros:
                     minor_branch.latest_micro = max(micros)
 


### PR DESCRIPTION
## Summary

A pre-GA hotfix branch (e.g. `hotfix/10.0.0`) permanently reserves its `X.Y.Z` version the moment it is cut: every version it can ever produce is `X.Y.Z.<hfrev>` (`.0` pre-GA, `.1`+ post-GA), never a bare `X.Y.Z`. The parent dev branch (`development/10.0`) must therefore target `X.Y.(Z+1)`, not `X.Y.Z`, or a later `X.Y.Z` tag cut from the dev branch would collide with the hotfix line while describing different code. `development/<major>` already implemented this correctly against `hotfix/<major>.0.0`; `development/<major>.<minor>` did not.

Two separate gaps needed fixing, both in `BranchCascade` (`bert_e/workflow/gitwaterflow/branches.py`):

1. **`_update_major_versions()`** — the minor-branch path computed `latest_micro` only from real cascade entries, never from phantom hotfix branches (`self._phantom_hotfixes`), unlike the major-only path which already folded them into `latest_minor`. Fixed by mirroring that existing pattern.
2. **`_set_target_versions()`** — even after (1), the tag-driven `_next_micro` (set by `update_versions()` from existing tags) takes unconditional priority and was never itself checked against phantom hotfixes. This meant the *common* case — a hotfix cut to patch an **already-tagged** micro line (e.g. `hotfix/9.5.3` branched after `9.5.0`/`9.5.1`/`9.5.2` were already tagged) — still collided: `development/9.5` kept targeting `9.5.3` instead of `9.5.4`. Fixed by clamping the computed `next_micro` to at least `reserved_micro + 1` whenever a phantom hotfix reserves a micro on the same line, regardless of which code path produced the initial value.

Audited the rest of the cascade for the same class of gap (queueing.py, jira.py's Fix Version check, the major-only path, 3-digit dev branches) — no other instance found; see commit messages for the reasoning trail.

Ref: [BERTE-609](https://scality.atlassian.net/browse/BERTE-609)

(Supersedes #277, closed automatically when its source branch was renamed to follow the `bugfix/BERTE-609-...` naming convention.)

## Test plan

- [x] `test_branch_cascade_2digit_with_pre_ga_hotfix` updated (no prior tag at the reserved micro)
- [x] New `test_branch_cascade_pre_ga_hotfix_after_prior_releases` added (hotfix cut after prior micro releases already tagged — the realistic case, and the one that exposed gap 2)
- [x] Full `QuickTest` cascade/hotfix/phantom test class passing (30 tests)
- [x] `test_queueing.py`/`test_jira.py` unit tests passing
- [x] Verified unrelated `TestQueueing`/`TaskQueueTests` failures pre-exist on unmodified `main` (require the full mock-server CLI harness, not bare pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BERTE-609]: https://scality.atlassian.net/browse/BERTE-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ